### PR TITLE
use a trie for matching URLs

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -15,7 +15,8 @@ var http = require('http'),
     log = require('loglevel'),
     util = require('util'),
     parse_url = require('url').parse,
-    parse_query = require('querystring').parse;
+    parse_query = require('querystring').parse,
+    URLTrie = require('./trie.js').URLTrie;
 
 var bound = function (that, method) {
     // bind a method, to ensure `this=that` when it is called
@@ -85,6 +86,7 @@ var authorized = function (method) {
 var ConfigurableProxy = function (options) {
     var that = this;
     this.options = options || {};
+    this.trie = new URLTrie();
     this.auth_token = this.options.auth_token;
     this.default_target = this.options.default_target;
     this.routes = {};
@@ -140,6 +142,7 @@ var ConfigurableProxy = function (options) {
 ConfigurableProxy.prototype.add_route = function (path, data) {
     // add a route to the routing table
     this.routes[path] = data;
+    this.trie.add(path, data);
     this.update_last_activity(path);
 };
 
@@ -147,6 +150,7 @@ ConfigurableProxy.prototype.remove_route = function (path) {
     // remove a route from teh routing table
     if (this.routes[path] !== undefined) {
         delete this.routes[path];
+        this.trie.remove(path);
     }
 };
 
@@ -216,34 +220,23 @@ ConfigurableProxy.prototype.delete_routes = function (req, res, path) {
     res.end();
 };
 
-var url_startswith = function (url, prefix) {
-    // does the url path start with prefix?
-    // use array splitting to match prefix and avoid trailing-slash and partial-word issues
-    var prefix_parts = prefix.split('/');
-    var parts = url.split('/');
-    if (parts.length < prefix_parts.length) {
-        return false;
-    }
-    for (var i = 0; i < prefix_parts.length; i++) {
-         if (prefix_parts[i] != parts[i]) {
-             return false;
-         }
-    }
-    return true;
-};
-
 ConfigurableProxy.prototype.target_for_url = function (url) {
     // return proxy target for a given url path
-    for (var prefix in this.routes) {
-        if (url_startswith(url, prefix)) {
-            return [prefix, this.routes[prefix].target];
-        }
+    var route = this.trie.get(url);
+    if (route) {
+        return {
+            prefix: route.prefix,
+            target: route.data.target,
+        };
     }
     // no custom target, fall back to default
     if (!this.default_target) {
         return;
     }
-    return ['/', this.default_target];
+    return {
+        prefix: '/',
+        target: this.default_target
+    };
 };
 
 ConfigurableProxy.prototype.update_last_activity = function (prefix) {
@@ -261,13 +254,13 @@ ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     // proxy any request
     var that = this;
     // get the proxy target
-    var both = this.target_for_url(req.url);
-    if (!both) {
+    var match = this.target_for_url(req.url);
+    if (!match) {
         fail(req, res, 404, "No target for: " + req.url);
         return;
     }
-    var prefix = both[0];
-    var target = both[1];
+    var prefix = match.prefix;
+    var target = match.target;
     log.debug("PROXY", kind.toUpperCase(), req.url, "to", target);
     
     // pop method off the front

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -1,0 +1,88 @@
+// A simple trie for URL prefix matching
+//
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+//
+// Store data at nodes in the trie with Trie.add("/path/", {data})
+//
+// Get data for a prefix with Trie.get("/path/to/something/inside")
+//
+// jshint node: true
+"use strict";
+
+var URLTrie = function (prefix) {
+    this.prefix = prefix || '';
+    this.children = {};
+    this.leaves = {};
+    this.size = 0;
+};
+
+var _slashes_re = /^[\/]+|[\/]+$/g;
+var string_to_path = function (s) {
+    // console.log("s, '%s'", s);
+    return s.replace(_slashes_re, "").split('/');
+};
+
+URLTrie.prototype.add = function (path, data) {
+    // add data to a node in the trie at path
+    if (typeof path === 'string') {
+        path = string_to_path(path);
+    }
+    var part = path.shift();
+    if (path.length === 0) {
+        this.leaves[part] = data;
+        this.size += 1;
+        return;
+    }
+    if (!this.children.hasOwnProperty(part)) {
+        this.children[part] = new URLTrie(this.prefix + '/' + part);
+        this.size += 1;
+    }
+    this.children[part].add(path, data);
+};
+
+URLTrie.prototype.remove = function (path) {
+    // remove `path` from the trie
+    if (typeof path === 'string') {
+        path = string_to_path(path);
+    }
+    var part = path.shift();
+    if (path.length === 0) {
+        delete this.leaves[part];
+        this.size -= 1;
+        return;
+    }
+    var child = this.children[part];
+    child.remove(path);
+    if (child.size === 0) {
+        delete this.children[part];
+        this.size -= 1;
+    }
+};
+
+URLTrie.prototype.get = function (path) {
+    // get the data stored at a matching prefix
+    // returns: 
+    // {
+    //  prefix: "/the/matching/prefix",
+    //  data: {whatever: "was stored by add"}
+    // }
+    if (typeof path === 'string') {
+        path = string_to_path(path);
+    }
+    var part = path.shift();
+    if (path.length === 0) {
+        return this.leaves[part];
+    }
+    var child = this.children[part];
+    if (child === undefined) {
+        return {
+            prefix: this.prefix,
+            data: this.leaves[part],
+        };
+    } else {
+        return child.get(path);
+    }
+};
+
+exports.URLTrie = URLTrie;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "lib/configproxy.js",
+    "lib/trie.js",
     "bin/configurable-http-proxy"
   ],
   "bin": {


### PR DESCRIPTION
avoid O(N) prefix matching

Using [ab](http://httpd.apache.org/docs/current/programs/ab.html), I no longer see any performance penalty for up to a million routes.

With master, I saw an overhead of 100ms for 10k routes and ~800ms for 100k.

Still some testing to do to make sure I did this right.
