### PR TITLE
Start base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install -g
 
 USER nobody
 
-CMD ["configurable-http-proxy"]
+ENTRYPOINT ["configurable-http-proxy"]


### PR DESCRIPTION
This gets us started with a base Dockerfile. The way that folks will interact with this will have to be through appropriate container linking.

Example runs:

```
$ docker run jupyter/configurable-http-proxy
REST API is not authenticated.
Proxying http://*:8000 to (no default)
Proxy API at http://localhost:8001/api/routes
$ docker run -e CONFIGPROXY_AUTH_TOKEN=legitrandom jupyter/configurable-http-proxy
Proxying http://*:8000 to (no default)
Proxy API at http://localhost:8001/api/routes
$ docker run -e CONFIGPROXY_AUTH_TOKEN=legit jupyter/configurable-http-proxy configurable-http-proxy --default-target=https://github.com/
Proxying http://*:8000 to https://github.com/
Proxy API at http://localhost:8001/api/routes
```

It might be better to change the entrypoint so it defaults to `configurable-http-proxy` so that a user can set the command line options directly.
