### PR TITLE
remove special case for default_target

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -77,7 +77,7 @@ proxy.api_server.listen(listen.api_port, listen.api_ip);
 log.info("Proxying %s://%s:%s to %s",
     options.ssl ? 'https' : 'http',
     (listen.ip || '*'), listen.port,
-    proxy.default_target || "(no default)"
+    options.default_target || "(no default)"
 );
 log.info("Proxy API at %s://%s:%s/api/routes",
     options.api_ssl ? 'https' : 'http',

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -7,7 +7,7 @@
 // GET /api/routes to see the current routing table
 //
 // jshint node: true
-// "use strict";
+"use strict";
 
 var http = require('http'),
     https = require('https'),
@@ -16,7 +16,7 @@ var http = require('http'),
     util = require('util'),
     parse_url = require('url').parse,
     parse_query = require('querystring').parse,
-    URLTrie = require('./trie.js').URLTrie;
+    trie = require('./trie.js');
 
 var bound = function (that, method) {
     // bind a method, to ensure `this=that` when it is called
@@ -86,10 +86,14 @@ var authorized = function (method) {
 var ConfigurableProxy = function (options) {
     var that = this;
     this.options = options || {};
-    this.trie = new URLTrie();
+    this.trie = new trie.URLTrie();
     this.auth_token = this.options.auth_token;
-    this.default_target = this.options.default_target;
     this.routes = {};
+    if (this.options.default_target) {
+        this.add_route('/', {
+            target: this.options.default_target
+        });
+    }
     
     var proxy = this.proxy = httpProxy.createProxyServer({
         ws : true
@@ -99,10 +103,8 @@ var ConfigurableProxy = function (options) {
     // because cross-language cargo-culting is always a good idea
     
     this.api_handlers = [
-        [ /^\/api\/routes\/?$/, {
-            get : bound(this, authorized(this.get_routes))
-        } ],
-        [ /^\/api\/routes(\/.*)$/, {
+        [ /^\/api\/routes(\/.*)?$/, {
+            get : bound(this, authorized(this.get_routes)),
             post : json_handler(bound(this, authorized(this.post_routes))),
             'delete' : bound(this, authorized(this.delete_routes))
         } ]
@@ -141,6 +143,7 @@ var ConfigurableProxy = function (options) {
 
 ConfigurableProxy.prototype.add_route = function (path, data) {
     // add a route to the routing table
+    path = trie.trim_prefix(path);
     this.routes[path] = data;
     this.trie.add(path, data);
     this.update_last_activity(path);
@@ -188,21 +191,15 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
 
 ConfigurableProxy.prototype.post_routes = function (req, res, path, data) {
     // POST adds a new route
+    path = path || '/';
     log.debug('POST', path, data);
     
-    // ensure path starts with /
-    if (path[0] != '/') {
-        path = '/' + path;
-    }
-    // ensure path *doesn't* end with /
-    if (path[path.length - 1] == '/') {
-        path = path.substr(0, path.length - 1);
-    }
     if (typeof data.target !== 'string') {
         log.warn("Bad POST data: %s", JSON.stringify(data));
         fail(req, res, 400, "Must specify 'target' as string");
         return;
     }
+    
     this.add_route(path, data);
     res.writeHead(201);
     res.end();
@@ -229,21 +226,10 @@ ConfigurableProxy.prototype.target_for_url = function (url) {
             target: route.data.target,
         };
     }
-    // no custom target, fall back to default
-    if (!this.default_target) {
-        return;
-    }
-    return {
-        prefix: '/',
-        target: this.default_target
-    };
 };
 
 ConfigurableProxy.prototype.update_last_activity = function (prefix) {
     // note last activity in routing table
-    if (prefix === '/') {
-        return;
-    }
     if (this.routes[prefix] !== undefined) {
         // route may have been deleted with open connections
         this.routes[prefix].last_activity = new Date();

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -10,15 +10,37 @@
 // jshint node: true
 "use strict";
 
+var trim_prefix = function (prefix) {
+    // cleanup prefix form: /foo/bar
+    // ensure prefix starts with /
+    if (prefix.length === 0 || prefix[0] !== '/') {
+        prefix = '/' + prefix;
+    }
+    // ensure prefix *doesn't* end with / (unless it's exactly /)
+    if (prefix.length > 1 && prefix[prefix.length - 1] === '/') {
+        prefix = prefix.substr(0, prefix.length - 1);
+    }
+    return prefix;
+};
+exports.trim_prefix = trim_prefix;
+
 var URLTrie = function (prefix) {
-    this.prefix = prefix || '';
+    // create a new URLTrie with data
+    this.prefix = trim_prefix(prefix || '/');
     this.branches = {};
     this.size = 0;
 };
 
 var _slashes_re = /^[\/]+|[\/]+$/g;
 var string_to_path = function (s) {
-    return s.replace(_slashes_re, "").split('/');
+    // turn a /prefix/string/ into ['prefix', 'string']
+    s = s.replace(_slashes_re, "");
+    if (s.length === 0) {
+        // special case because ''.split() gives [''], which is wrong.
+        return [];
+    } else {
+        return s.split('/');
+    }
 };
 
 URLTrie.prototype.add = function (path, data) {
@@ -32,7 +54,9 @@ URLTrie.prototype.add = function (path, data) {
     }
     var part = path.shift();
     if (!this.branches.hasOwnProperty(part)) {
-        this.branches[part] = new URLTrie(this.prefix + '/' + part);
+        // join with /, and handle the fact that only root ends with '/'
+        var prefix = this.prefix.length === 1 ? this.prefix : this.prefix + '/';
+        this.branches[part] = new URLTrie(prefix + part);
         this.size += 1;
     }
     this.branches[part].add(path, data);

--- a/test/trie_spec.js
+++ b/test/trie_spec.js
@@ -26,7 +26,7 @@ describe("URLTrie", function () {
 
     it("trie_init", function (done) {
         var trie = new URLTrie();
-        expect(trie.prefix).toEqual('');
+        expect(trie.prefix).toEqual('/');
         expect(trie.size).toEqual(0);
         expect(trie.data).toBe(undefined);
         expect(trie.branches).toEqual({});
@@ -40,6 +40,26 @@ describe("URLTrie", function () {
         done();
     });
 
+    it("trie_root", function (done) {
+        var trie = new URLTrie();
+        trie.add('/', -1);
+        var node = trie.get('/1/etc/etc/');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        expect(node.data).toEqual(-1);
+
+        var node = trie.get('/');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        expect(node.data).toEqual(-1);
+
+        var node = trie.get('');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        expect(node.data).toEqual(-1);
+        done();
+    });
+    
     it("trie_add", function (done) {
         var trie = new URLTrie();
     


### PR DESCRIPTION
now handled as just `/` in routing table

this means that the default target is included in the REST API, and can be modified just like any other.
