### PR TITLE
Use http-proxy 1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "commander": "~2",
-    "http-proxy": "~1",
+    "http-proxy": "1.4.3",
     "winston": "~0.8",
     "strftime": "~0.8"
   },


### PR DESCRIPTION
http-proxy 1.5.0 seems to have issues with websockets. Lock to 1.4.3 for now.
