### PR TITLE
passthrough options to node-http-proxy

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -25,7 +25,11 @@ args
     .option('--api-ssl-key <keyfile>', 'SSL key to use, if any, for API requests')
     .option('--api-ssl-cert <certfile>', 'SSL certificate to use, if any, for API requests')
     .option('--default-target <host>', 'Default proxy target (proto://host[:port]')
+    // passthrough http-proxy options
     .option('--no-x-forward', "Don't add 'X-forward-' headers to proxied requests")
+    .option('--no-prepend-path', "Proxy /prefix/foo to /foo instead of /prefix/foo instead." + 
+        "  Allows proxied application to be ignorant of proxy prefix.")
+    .option('--insecure', "Disable SSL cert verification")
     .option('--log-level <loglevel>', 'Log level (debug, info, warn, error)', 'info');
 
 args.parse(process.argv);
@@ -69,7 +73,11 @@ if (args.apiSslKey || args.apiSslCert) {
 // because camelCase is the js way!
 options.default_target = args.defaultTarget;
 options.auth_token = process.env.CONFIGPROXY_AUTH_TOKEN;
+
+// passthrough for http-proxy options
 options.xfwd = args.noXHeaders ? false : true;
+if (args.insecure) options.secure = false;
+if (args.noPrependPath) options.prependPath = false;
 
 if (!options.auth_token) {
     log.warn("REST API is not authenticated.");

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -99,11 +99,8 @@ var ConfigurableProxy = function (options) {
             target: this.options.default_target
         });
     }
-    
-    var proxy = this.proxy = httpProxy.createProxyServer({
-        xfwd: this.options.xfwd,
-        ws : true
-    });
+    options.ws = true;
+    var proxy = this.proxy = httpProxy.createProxyServer(options);
     
     // tornado-style regex routing,
     // because cross-language cargo-culting is always a good idea


### PR DESCRIPTION
adds `--insecure` and `--no-prepend-path` for `secure: false` and `prependPath: false`, respectively.
