### PR TITLE
Crank max sockets to infinity

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -11,7 +11,12 @@
 var fs = require('fs'),
     args = require('commander'),
     strftime = require('strftime'),
-    log = require('winston');
+    log = require('winston'),
+    http = require('http'),
+    https = require('https');
+
+http.globalAgent.maxSockets = Infinity;
+https.globalAgent.maxSockets = Infinity;
 
 args
     .version('0.1.2-dev')

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -18,9 +18,6 @@ var http = require('http'),
     parse_query = require('querystring').parse,
     trie = require('./trie.js');
 
-http.globalAgent.maxSockets = Infinity;
-https.globalAgent.maxSockets = Infinity;
-
 var bound = function (that, method) {
     // bind a method, to ensure `this=that` when it is called
     // because prototype languages are bad


### PR DESCRIPTION
Since we keep running into socket and file descriptor limits, set `maxSockets` to `Infinity`.

I freely admit that I'm cargo culting this from my colleague @kenperkins.
