### PR TITLE
add `--no-include-prefix`

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -28,6 +28,7 @@ args
     // passthrough http-proxy options
     .option('--no-x-forward', "Don't add 'X-forward-' headers to proxied requests")
     .option('--no-prepend-path', "Avoid prepending target paths to proxied requests")
+    .option('--no-include-prefix', "Don't include the routing prefix in proxied requests")
     .option('--insecure', "Disable SSL cert verification")
     .option('--log-level <loglevel>', 'Log level (debug, info, warn, error)', 'info');
 
@@ -74,9 +75,10 @@ options.default_target = args.defaultTarget;
 options.auth_token = process.env.CONFIGPROXY_AUTH_TOKEN;
 
 // passthrough for http-proxy options
-options.xfwd = args.noXHeaders ? false : true;
 if (args.insecure) options.secure = false;
-if (args.prependPath !== undefined) options.prependPath = args.prependPath;
+options.xfwd = args.noXHeaders ? false : true;
+options.prependPath = args.prependPath;
+options.includePrefix = args.includePrefix;
 
 if (!options.auth_token) {
     log.warn("REST API is not authenticated.");

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -93,6 +93,7 @@ var ConfigurableProxy = function (options) {
     this.options = options || {};
     this.trie = new trie.URLTrie();
     this.auth_token = this.options.auth_token;
+    this.includePrefix = options.includePrefix === undefined ? true : options.includePrefix;
     this.routes = {};
     if (this.options.default_target) {
         this.add_route('/', {
@@ -251,6 +252,9 @@ ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     var prefix = match.prefix;
     var target = match.target;
     log.debug("PROXY", kind.toUpperCase(), req.url, "to", target);
+    if (!this.includePrefix) {
+        req.url = req.url.slice(prefix.length);
+    }
     
     // pop method off the front
     var args = arguments_array(arguments);

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -64,15 +64,14 @@ describe("Proxy Tests", function () {
         });
     });
     
-    it("target path is prepended", function (done) {
+    it("target path is prepended by default", function (done) {
         util.add_target(proxy, '/bar', port + 10, false, '/foo');
-        r(proxy_url + '/bar', function (error, res, body) {
+        r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
             expect(res.statusCode).toEqual(200);
             body = JSON.parse(body);
-            console.log(body);
             expect(body).toEqual(jasmine.objectContaining({
                 path: '/bar',
-                url: '/foo/bar'
+                url: '/foo/bar/rest/of/it'
             }));
             done();
         });
@@ -81,13 +80,41 @@ describe("Proxy Tests", function () {
     it("prependPath: false prevents target path from being prepended", function (done) {
         proxy.proxy.options.prependPath = false;
         util.add_target(proxy, '/bar', port + 10, false, '/foo');
-        r(proxy_url + '/bar', function (error, res, body) {
+        r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
             expect(res.statusCode).toEqual(200);
             body = JSON.parse(body);
-            console.log(body);
             expect(body).toEqual(jasmine.objectContaining({
                 path: '/bar',
-                url: '/bar'
+                url: '/bar/rest/of/it'
+            }));
+            done();
+        });
+    });
+    
+    it("includePrefix: false strips routing prefix from request", function (done) {
+        proxy.includePrefix = false;
+        util.add_target(proxy, '/bar', port + 10, false, '/foo');
+        r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
+            expect(res.statusCode).toEqual(200);
+            body = JSON.parse(body);
+            expect(body).toEqual(jasmine.objectContaining({
+                path: '/bar',
+                url: '/foo/rest/of/it'
+            }));
+            done();
+        });
+    });
+    
+    it("includePrefix: false + prependPath: false", function (done) {
+        proxy.includePrefix = false;
+        proxy.proxy.options.prependPath = false;
+        util.add_target(proxy, '/bar', port + 10, false, '/foo');
+        r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
+            expect(res.statusCode).toEqual(200);
+            body = JSON.parse(body);
+            expect(body).toEqual(jasmine.objectContaining({
+                path: '/bar',
+                url: '/rest/of/it'
             }));
             done();
         });


### PR DESCRIPTION
aka `includePrefix: false`

if set, strips the routing prefix from the forwarded request URL, allowing `/prefix/foo` to be routed to `target/foo`.

implements feature requested in #19
