### PR TITLE
fix sub-trie prefix matching

### DIFF
--- a/lib/trie.js
+++ b/lib/trie.js
@@ -89,18 +89,33 @@ URLTrie.prototype.get = function (path) {
     //  prefix: "/the/matching/prefix",
     //  data: {whatever: "was stored by add"}
     // }
+    
+    // if I have data, return me, otherwise return undefined
+    var me = this.data === undefined ? undefined: this;
+    
     if (typeof path === 'string') {
         path = string_to_path(path);
     }
     if (path.length === 0) {
-        return this.data === undefined ? undefined: this;
+        // exact match, it's definitely me!
+        return me;
     }
     var part = path.shift();
     var child = this.branches[part];
     if (child === undefined) {
-        return this.data === undefined ? undefined: this;
+        // prefix matches, and I don't have any more specific children
+        return me;
     } else {
-        return child.get(path);
+        // I match and I have a more specific child that matches.
+        // That *does not* mean that I have a more specific *leaf* that matches.
+        var node = child.get(path);
+        if (node) {
+            // found a more specific leaf
+            return node;
+        } else {
+            // I'm still the most specific match
+            return me;
+        }
     }
 };
 

--- a/test/trie_spec.js
+++ b/test/trie_spec.js
@@ -153,4 +153,47 @@ describe("URLTrie", function () {
         done();
     });
 
+    it("trie_sub_paths", function (done) {
+        var trie = new URLTrie(), node;
+        trie.add('/', {
+            path: '/'
+        });
+        
+        node = trie.get('/prefix/sub');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        
+        // add /prefix/sub/tree
+        trie.add('/prefix/sub/tree', {});
+        
+        // which shouldn't change the results for /prefix and /prefix/sub
+        node = trie.get('/prefix');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        
+        node = trie.get('/prefix/sub');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/');
+        
+        node = trie.get('/prefix/sub/tree');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/prefix/sub/tree');
+        
+        // add /prefix, and run one more time
+        trie.add('/prefix', {});
+        
+        node = trie.get('/prefix');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/prefix');
+        
+        node = trie.get('/prefix/sub');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/prefix');
+        
+        node = trie.get('/prefix/sub/tree');
+        expect(node).toBeTruthy();
+        expect(node.prefix).toEqual('/prefix/sub/tree');
+        
+        done();
+    });
 });


### PR DESCRIPTION
when you have `/` and `/a/b/c`, `/a` and `/a/b` should be handled by `/`.
