### PR TITLE
use strict is unnecessary inside of modules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,5 @@
   "forin": true,
   "latedef": true,
   "node": true,
-  "strict": true,
   "undef": true
 }

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -6,8 +6,6 @@
 // Distributed under the terms of the Modified BSD License.
 //
 
-"use strict";
-
 var fs = require('fs'),
     pkg = require('../package.json'),
     args = require('commander'),

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -7,8 +7,6 @@
 // GET /api/routes to see the current routing table
 //
 
-"use strict";
-
 var http = require('http'),
     https = require('https'),
     fs = require('fs'),

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -1,5 +1,3 @@
-"use strict";
-
 var http = require('http');
 var URL = require('url');
 var extend = require('util')._extend;
@@ -57,7 +55,7 @@ exports.setup_proxy = function (port, callback, options, paths) {
         p = p + 1;
         add_target(proxy, path, p, true);
     });
-    
+
     var ip = '127.0.0.1';
 
     var countdown = 2;
@@ -69,7 +67,7 @@ exports.setup_proxy = function (port, callback, options, paths) {
             }
         }
     };
-    
+
     if (options.error_target) {
         countdown = countdown + 1;
         var error_server = http.createServer(function (req, res) {
@@ -86,7 +84,7 @@ exports.setup_proxy = function (port, callback, options, paths) {
         error_server.listen(URL.parse(options.error_target).port, ip);
         servers.push(error_server);
     }
-    
+
     proxy.proxy_server.listen(port, ip);
     proxy.api_server.listen(port + 1, ip);
     servers.push(proxy.proxy_server);
@@ -119,4 +117,3 @@ var onfinish = exports.onfinish = function (res, callback) {
       callback(res);
   });
 };
-

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -8,8 +8,6 @@
 // Get data for a prefix with Trie.get("/path/to/something/inside")
 //
 
-"use strict";
-
 function trim_prefix (prefix) {
     // cleanup prefix form: /foo/bar
     // ensure prefix starts with /
@@ -92,15 +90,15 @@ URLTrie.prototype.remove = function (path) {
 
 URLTrie.prototype.get = function (path) {
     // get the data stored at a matching prefix
-    // returns: 
+    // returns:
     // {
     //  prefix: "/the/matching/prefix",
     //  data: {whatever: "was stored by add"}
     // }
-    
+
     // if I have data, return me, otherwise return undefined
     var me = this.data === undefined ? undefined: this;
-    
+
     if (typeof path === 'string') {
         path = string_to_path(path);
     }

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -1,5 +1,4 @@
 // jshint jasmine: true
-"use strict";
 
 var util = require('../lib/testutil');
 var extend = require('util')._extend;
@@ -13,9 +12,9 @@ describe("API Tests", function () {
     var api_port = port + 1;
     var proxy;
     var api_url = "http://127.0.0.1:" + api_port + '/api/routes';
-    
+
     var r;
-    
+
     beforeEach(function (callback) {
         function setup_r() {
             r = request.defaults({
@@ -28,11 +27,11 @@ describe("API Tests", function () {
         }
         proxy = util.setup_proxy(port, setup_r);
     });
-    
+
     afterEach(function (callback) {
         util.teardown_servers(callback);
     });
-    
+
     it("Basic proxy constructor", function () {
         expect(proxy).toBeDefined();
         expect(proxy.default_target).toBe(undefined);
@@ -41,7 +40,7 @@ describe("API Tests", function () {
             target: "http://127.0.0.1:" + (port + 2)
         });
     });
-    
+
     it("Default target is used for /any/random/url", function () {
         var target = proxy.target_for_req({url: '/any/random/url'});
         expect(target).toEqual({
@@ -49,7 +48,7 @@ describe("API Tests", function () {
             target: "http://127.0.0.1:" + (port + 2)
         });
     });
-    
+
     it("Default target is used for /", function () {
         var target = proxy.target_for_req({url: '/'});
         expect(target).toEqual({
@@ -57,7 +56,7 @@ describe("API Tests", function () {
             target: "http://127.0.0.1:" + (port + 2)
         });
     });
-    
+
     it("GET /api/routes fetches the routing table", function (done) {
         r(api_url, function (error, res, body) {
             expect(error).toBe(null);
@@ -69,7 +68,7 @@ describe("API Tests", function () {
             done();
         });
     });
-    
+
     it("POST /api/routes[/path] creates a new route", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
@@ -86,7 +85,7 @@ describe("API Tests", function () {
             done();
         });
     });
-    
+
     it("POST /api/routes[/foo%20bar] handles URI escapes", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
@@ -105,7 +104,7 @@ describe("API Tests", function () {
             done();
         });
     });
-    
+
     it("POST /api/routes creates a new root route", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
@@ -122,7 +121,7 @@ describe("API Tests", function () {
             done();
         });
     });
-    
+
     it("DELETE /api/routes[/path] deletes a route", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
@@ -137,23 +136,23 @@ describe("API Tests", function () {
             done();
         });
     });
-    
+
     it("GET /api/routes?inactive_since= filters inactive entries", function (done) {
         var port = 8998;
         var path = '/yesterday';
         util.add_target(proxy, '/yesterday', port);
         util.add_target(proxy, '/today', port+1);
-    
+
         var now = new Date();
         var yesterday = new Date(now.getTime() - (24 * 3.6e6));
         var long_ago = new Date(1);
         var hour_ago = new Date(now.getTime() - 3.6e6);
         var hour_from_now = new Date(now.getTime() + 3.6e6);
-        
+
         proxy.remove_route('/');
-        
+
         proxy.routes['/yesterday'].last_activity = yesterday;
-    
+
         var tests = [
             {
                 name: 'long ago',
@@ -174,12 +173,12 @@ describe("API Tests", function () {
                 },
             },
         ];
-        
+
         r.get(api_url + "?inactive_since=endoftheuniverse", function (error, res, body) {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(400);
         });
-    
+
         var seen = 0;
         var do_req = function (i) {
             var t = tests[i];
@@ -209,7 +208,7 @@ describe("API Tests", function () {
                 }
             });
         };
-    
+
         do_req(0);
     });
 });

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -1,5 +1,4 @@
 // jshint jasmine: true
-"use strict";
 
 var path = require('path');
 var util = require('../lib/testutil');
@@ -22,11 +21,11 @@ describe("Proxy Tests", function () {
     beforeEach(function (callback) {
         proxy = util.setup_proxy(port, callback);
     });
-    
+
     afterEach(function (callback) {
         util.teardown_servers(callback);
     });
-    
+
     it("basic HTTP request", function (done) {
         r(proxy_url, function (error, res, body) {
             expect(error).toBe(null);
@@ -38,7 +37,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("basic WebSocker request", function (done) {
         var ws = new WebSocket('ws://127.0.0.1:' + port);
         ws.on('error', function () {
@@ -65,14 +64,14 @@ describe("Proxy Tests", function () {
             ws.send('hi');
         });
     });
-    
+
     it("proxy_request event can modify headers", function (done) {
         var called = {};
         proxy.on('proxy_request', function (req, res) {
             req.headers.testing = 'Test Passed';
             called.proxy_request = true;
         });
-        
+
         r(proxy_url, function (error, res, body) {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(200);
@@ -84,11 +83,11 @@ describe("Proxy Tests", function () {
             expect(body.headers).toEqual(jasmine.objectContaining({
                 testing: 'Test Passed',
             }));
-            
+
             done();
         });
     });
-    
+
     it("target path is prepended by default", function (done) {
         util.add_target(proxy, '/bar', test_port, false, '/foo');
         r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
@@ -102,7 +101,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("handle URI encoding", function (done) {
         util.add_target(proxy, '/b@r/b r', test_port, false, '/foo');
         r(proxy_url + '/b%40r/b%20r/rest/of/it', function (error, res, body) {
@@ -116,7 +115,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("handle @ in URI same as %40", function (done) {
         util.add_target(proxy, '/b@r/b r', test_port, false, '/foo');
         r(proxy_url + '/b@r/b%20r/rest/of/it', function (error, res, body) {
@@ -130,7 +129,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("prependPath: false prevents target path from being prepended", function (done) {
         proxy.proxy.options.prependPath = false;
         util.add_target(proxy, '/bar', test_port, false, '/foo');
@@ -145,7 +144,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("includePrefix: false strips routing prefix from request", function (done) {
         proxy.includePrefix = false;
         util.add_target(proxy, '/bar', test_port, false, '/foo');
@@ -160,7 +159,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("includePrefix: false + prependPath: false", function (done) {
         proxy.includePrefix = false;
         proxy.proxy.options.prependPath = false;
@@ -191,7 +190,7 @@ describe("Proxy Tests", function () {
             done();
         });
     });
-    
+
     it("custom error target", function (done) {
         var port = 55555;
         util.setup_proxy(port, function (proxy) {
@@ -234,7 +233,7 @@ describe("Proxy Tests", function () {
         proxy.add_route('/missing', {
             target: 'https://127.0.0.1:54321',
         });
-        
+
         r(host_url + '/nope', function (error, res, body) {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(404);

--- a/test/trie_spec.js
+++ b/test/trie_spec.js
@@ -1,10 +1,9 @@
 // jshint jasmine: true
-"use strict";
 
 var URLTrie = require('../lib/trie').URLTrie;
 
 describe("URLTrie", function () {
-    
+
     var full_trie = function () {
         // return a simple trie for testing
         var trie = new URLTrie();
@@ -30,13 +29,13 @@ describe("URLTrie", function () {
         expect(trie.size).toEqual(0);
         expect(trie.data).toBe(undefined);
         expect(trie.branches).toEqual({});
-    
+
         trie = new URLTrie('/foo');
         expect(trie.size).toEqual(0);
         expect(trie.prefix).toEqual('/foo');
         expect(trie.data).toBe(undefined);
         expect(trie.branches).toEqual({});
-    
+
         done();
     });
 
@@ -59,13 +58,13 @@ describe("URLTrie", function () {
         expect(node.data).toEqual(-1);
         done();
     });
-    
+
     it("trie_add", function (done) {
         var trie = new URLTrie();
-    
+
         trie.add('foo', 1);
         expect(trie.size).toEqual(1);
-    
+
         expect(trie.data).toBe(undefined);
         expect(trie.branches.foo.data).toEqual(1);
         expect(trie.branches.foo.size).toEqual(0);
@@ -149,7 +148,7 @@ describe("URLTrie", function () {
         trie.remove('/a/b/c/d');
         expect(b.size).toEqual(2);
         expect(b.branches.c).toBe(undefined);
-        
+
         trie.remove('/');
         node = trie.get('/');
         expect(node).toBe(undefined);
@@ -162,42 +161,42 @@ describe("URLTrie", function () {
         trie.add('/', {
             path: '/'
         });
-        
+
         node = trie.get('/prefix/sub');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/');
-        
+
         // add /prefix/sub/tree
         trie.add('/prefix/sub/tree', {});
-        
+
         // which shouldn't change the results for /prefix and /prefix/sub
         node = trie.get('/prefix');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/');
-        
+
         node = trie.get('/prefix/sub');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/');
-        
+
         node = trie.get('/prefix/sub/tree');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/prefix/sub/tree');
-        
+
         // add /prefix, and run one more time
         trie.add('/prefix', {});
-        
+
         node = trie.get('/prefix');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/prefix');
-        
+
         node = trie.get('/prefix/sub');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/prefix');
-        
+
         node = trie.get('/prefix/sub/tree');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/prefix/sub/tree');
-        
+
         done();
     });
 
@@ -206,7 +205,7 @@ describe("URLTrie", function () {
         trie.add('/', {
             path: '/'
         });
-        
+
         node = trie.get('/prefix/sub');
         expect(node).toBeTruthy();
         expect(node.prefix).toEqual('/');


### PR DESCRIPTION
Wanting to get more involved on the config proxy and noticed that `"use strict"` was used. This isn't necessary inside of node modules, so I took it out.