### PR TITLE
run coverage with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+npm-debug.log
 node_modules
 *.py[co]
 *~
@@ -8,3 +9,4 @@ bench/results
 bench/html
 coverage
 dist
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - npm run -s jshint
   - travis_retry npm test
 after_success:
-  - codecov
+  - npm run codecov

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "winston": "~0.8"
   },
   "devDependencies": {
-    "istanbul": "^0.4.3",
     "jasmine-node": "~2",
     "jshint": "*",
+    "nyc": "^6.4.0",
     "request": "~2",
     "ws": "~0.4"
   },
@@ -35,7 +35,8 @@
   },
   "scripts": {
     "jshint": "jshint bin/ lib/ test/",
-    "test": "istanbul cover jasmine-node --captureExceptions test",
-    "test-cover-html": "istanbul cover --report html jasmine-node --captureExceptions test"
+    "test": "nyc jasmine-node --captureExceptions test",
+    "coverage-html": "nyc report --reporter=html",
+    "codecov": "nyc report --reporter=lcov && codecov"
   }
 }


### PR DESCRIPTION
seems to fix codecov reports

not sure why, but gitter discussion suggested weird coverage.json was the problem.