### PR TITLE
Fixes incorrect inversion of xForward.

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -180,7 +180,7 @@ if (options.error_target && options.error_path) {
 
 // passthrough for http-proxy options
 if (args.insecure) options.secure = false;
-options.xfwd = args.xForward ? false : true;
+options.xfwd = args.xForward;
 options.prependPath = args.prependPath;
 options.includePrefix = args.includePrefix;
 if (args.autoRewrite) {


### PR DESCRIPTION
commander already handles -no- options appropriately, there's no need
to reverse the logic.