### PR TITLE
Separate storage mechanism for routes

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -290,7 +290,7 @@ ConfigurableProxy.prototype.update_last_activity = function (prefix) {
     // note last activity in routing table
     if (this._routes.hasRoute(prefix)) {
         // route may have been deleted with open connections
-        this._routes.get(prefix).last_activity = new Date();
+        this._routes.update(prefix, { "last_activity": new Date() });
     }
     timer.stop();
 };

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -208,9 +208,9 @@ ConfigurableProxy.prototype.remove_route = function (path, cb) {
     var routes = this._routes;
 
     routes.hasRoute(path, function (result) {
-      if (result) {
-        routes.remove(path, cb);
-      }
+        if (result) {
+            routes.remove(path, cb);
+        }
     });
 };
 
@@ -221,7 +221,7 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
     var inactive_since = null;
     if (parsed.query) {
         var query = querystring.parse(parsed.query);
-        
+
         if (query.inactive_since !== undefined) {
             var timestamp = Date.parse(query.inactive_since);
             if (isFinite(timestamp)) {
@@ -238,15 +238,14 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
         var results = {};
 
         if (inactive_since) {
-            var keys = Object.keys(routes).filter(function (key) {
-                return routes[key].last_activity < inactive_since;
+            Object.keys(routes).forEach(function (path) {
+                if (routes[path].last_activity < inactive_since) {
+                    results[path] = routes[path];
+                }
             });
-
-            keys.forEach(function (key) { results[key] = routes[key]; });
         } else {
             results = routes;
         }
-
 
         res.write(JSON.stringify(results));
         res.end();
@@ -300,8 +299,15 @@ ConfigurableProxy.prototype.target_for_req = function (req, cb) {
 
     this._routes.getTarget(base_path + decodeURIComponent(req.url), function (route) {
         timer.stop();
-        var result = route ? { prefix: route.prefix, target: route.data.target } : null;
-        cb(result);
+        if (route) {
+            cb({
+                prefix: route.prefix,
+                target: route.data.target
+            });
+            return;
+        }
+
+        cb(null);
     });
 };
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -169,7 +169,7 @@ function ConfigurableProxy (options) {
     }
 
     // proxy requests separately
-    var proxy_callback = log_errors(that.handle_proxy_web);
+    var proxy_callback = log_errors(this.handle_proxy_web);
     if ( this.options.ssl ) {
         this.proxy_server = https.createServer(this.options.ssl, proxy_callback);
     } else {
@@ -185,21 +185,33 @@ function ConfigurableProxy (options) {
 
 util.inherits(ConfigurableProxy, EventEmitter);
 
-ConfigurableProxy.prototype.add_route = function (path, data) {
+ConfigurableProxy.prototype.add_route = function (path, data, cb) {
     // add a route to the routing table
     path = this._routes.cleanPath(path);
     if (this.host_routing && path !== '/') {
         data.host = path.split('/')[1];
     }
-    this._routes.add(path, data);
-    this.update_last_activity(path);
+
+    var that = this;
+
+    this._routes.add(path, data, function () {
+      that.update_last_activity(path, function () {
+        if (typeof(cb) === "function") {
+          cb();
+        }
+      });
+    });
 };
 
-ConfigurableProxy.prototype.remove_route = function (path) {
+ConfigurableProxy.prototype.remove_route = function (path, cb) {
     // remove a route from the routing table
-    if (this._routes.hasRoute(path)) {
-        this._routes.remove(path);
-    }
+    var routes = this._routes;
+
+    routes.hasRoute(path, function (result) {
+      if (result) {
+        routes.remove(path, cb);
+      }
+    });
 };
 
 ConfigurableProxy.prototype.get_routes = function (req, res) {
@@ -221,20 +233,25 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
         }
     }
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    var routes = {};
-    if (inactive_since) {
-        Object.keys(this._routes.getAll()).map(function (path) {
-            var route = that._routes.get(path);
-            if (route.last_activity < inactive_since) {
-                routes[path] = route;
-            }
-        });
-    } else {
-        routes = this._routes.getAll();
-    }
-    res.write(JSON.stringify(routes));
-    res.end();
-    this.statsd.increment('api.route.get', 1);
+
+    this._routes.getAll(function (routes) {
+        var results = {};
+
+        if (inactive_since) {
+            var keys = Object.keys(routes).filter(function (key) {
+                return routes[key].last_activity < inactive_since;
+            });
+
+            keys.forEach(function (key) { results[key] = routes[key]; });
+        } else {
+            results = routes;
+        }
+
+
+        res.write(JSON.stringify(results));
+        res.end();
+        that.statsd.increment('api.route.get', 1);
+    });
 };
 
 ConfigurableProxy.prototype.post_routes = function (req, res, path, data) {
@@ -248,47 +265,63 @@ ConfigurableProxy.prototype.post_routes = function (req, res, path, data) {
         return;
     }
 
-    this.add_route(path, data);
-    res.writeHead(201);
-    res.end();
-    this.statsd.increment('api.route.add', 1);
+    var that = this;
+    this.add_route(path, data, function () {
+        res.writeHead(201);
+        res.end();
+        that.statsd.increment('api.route.add', 1);
+    });
 };
 
 ConfigurableProxy.prototype.delete_routes = function (req, res, path) {
     // DELETE removes an existing route
     log.debug('DELETE', path);
-    if (this._routes.hasRoute(path)) {
-        this.remove_route(path);
-        res.writeHead(204);
-    } else {
-        res.writeHead(404);
-    }
-    res.end();
-    this.statsd.increment('api.route.delete', 1);
+
+    var that = this;
+    this._routes.hasRoute(path, function (result) {
+        if (result) {
+            that.remove_route(path, function () {
+                res.writeHead(204);
+                res.end();
+                that.statsd.increment('api.route.delete', 1);
+            });
+        } else {
+            res.writeHead(404);
+            res.end();
+            that.statsd.increment('api.route.delete', 1);
+        }
+    });
 };
 
-ConfigurableProxy.prototype.target_for_req = function (req) {
+ConfigurableProxy.prototype.target_for_req = function (req, cb) {
     var timer = this.statsd.createTimer('find_target_for_req');
     // return proxy target for a given url path
     var base_path = (this.host_routing) ? '/' + parse_host(req) : '';
-    var route = this._routes.getTarget(base_path + decodeURIComponent(req.url));
-    timer.stop();
-    if (route) {
-        return {
-            prefix: route.prefix,
-            target: route.data.target,
-        };
-    }
+
+    this._routes.getTarget(base_path + decodeURIComponent(req.url), function (route) {
+        timer.stop();
+        var result = route ? { prefix: route.prefix, target: route.data.target } : null;
+        cb(result);
+    });
 };
 
-ConfigurableProxy.prototype.update_last_activity = function (prefix) {
+ConfigurableProxy.prototype.update_last_activity = function (prefix, cb) {
     var timer = this.statsd.createTimer('last_activity_updating');
-    // note last activity in routing table
-    if (this._routes.hasRoute(prefix)) {
-        // route may have been deleted with open connections
-        this._routes.update(prefix, { "last_activity": new Date() });
-    }
-    timer.stop();
+    var routes = this._routes;
+
+    routes.hasRoute(prefix, function (result) {
+        cb = cb || function() {};
+
+        if (result) {
+            routes.update(prefix, { "last_activity": new Date() }, function () {
+                timer.stop();
+                cb();
+            });
+        } else {
+            timer.stop();
+            cb();
+        }
+    });
 };
 
 ConfigurableProxy.prototype._handle_proxy_error_default = function (code, kind, req, res) {
@@ -361,48 +394,47 @@ ConfigurableProxy.prototype.handle_proxy_error = function (code, kind, req, res)
 ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     // proxy any request
     var that = this;
+    var args = Array.prototype.slice.call(arguments, 1);
+
     // get the proxy target
-    var match = this.target_for_req(req);
-    if (!match) {
-        this.handle_proxy_error(404, kind, req, res);
-        return;
-    }
-    this.emit("proxy_request", req, res);
-    var prefix = match.prefix;
-    var target = match.target;
-    log.debug("PROXY", kind.toUpperCase(), req.url, "to", target);
-    if (!this.includePrefix) {
-        req.url = req.url.slice(prefix.length);
-    }
+    this.target_for_req(req, function (match) {
+        if (!match) {
+            that.handle_proxy_error(404, kind, req, res);
+            return;
+        }
 
-    // pop method off the front
-    var args = arguments_array(arguments);
-    args.shift();
+        that.emit("proxy_request", req, res);
+        var prefix = match.prefix;
+        var target = match.target;
+        log.debug("PROXY", kind.toUpperCase(), req.url, "to", target);
+        if (!that.includePrefix) {
+            req.url = req.url.slice(prefix.length);
+        }
 
-    // add config argument
-    args.push({
-        target: target
+        // add config argument
+        args.push({ target: target });
+
+        // add error handling
+        args.push(function (e) {
+            log.error("Proxy error: ", e);
+            that.handle_proxy_error(503, kind, req, res);
+        });
+
+        // update timestamp on any reply data as well (this includes websocket data)
+        req.on('data', function () {
+            that.update_last_activity(prefix);
+        });
+
+        res.on('data', function () {
+            that.update_last_activity(prefix);
+        });
+
+        // update last activity timestamp in routing table
+        that.update_last_activity(prefix, function () {
+            // dispatch the actual method
+            that.proxy[kind].apply(that.proxy, args);
+        });
     });
-
-    // add error handling
-    args.push(function (e) {
-        log.error("Proxy error: ", e);
-        that.handle_proxy_error(503, kind, req, res);
-    });
-
-    // update last activity timestamp in routing table
-    this.update_last_activity(prefix);
-
-    // update timestamp on any reply data as well (this includes websocket data)
-    req.on('data', function () {
-        that.update_last_activity(prefix);
-    });
-    res.on('data', function () {
-        that.update_last_activity(prefix);
-    });
-
-    // dispatch the actual method
-    this.proxy[kind].apply(this.proxy, args);
 };
 
 ConfigurableProxy.prototype.handle_proxy_ws = function (req, res, head) {

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -17,6 +17,7 @@ var http = require('http'),
     util = require('util'),
     URL = require('url'),
     querystring = require('querystring'),
+    store = require('./store.js'),
     trie = require('./trie.js');
 
 function bound (that, method) {
@@ -100,10 +101,11 @@ function parse_host (req) {
 function ConfigurableProxy (options) {
     var that = this;
     this.options = options || {};
+
+    this._routes = store.MemoryStore();
     this.trie = new trie.URLTrie();
     this.auth_token = this.options.auth_token;
     this.includePrefix = options.includePrefix === undefined ? true : options.includePrefix;
-    this.routes = {};
     this.host_routing = this.options.host_routing;
     this.error_target = options.error_target;
     if (this.error_target && this.error_target.slice(-1) !== '/') {
@@ -191,15 +193,15 @@ ConfigurableProxy.prototype.add_route = function (path, data) {
     if (this.host_routing && path !== '/') {
         data.host = path.split('/')[1];
     }
-    this.routes[path] = data;
+    this._routes.add(path, data);
     this.trie.add(path, data);
     this.update_last_activity(path);
 };
 
 ConfigurableProxy.prototype.remove_route = function (path) {
     // remove a route from the routing table
-    if (this.routes[path] !== undefined) {
-        delete this.routes[path];
+    if (this._routes.hasRoute(path)) {
+        this._routes.remove(path);
         this.trie.remove(path);
     }
 };
@@ -225,14 +227,14 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     var routes = {};
     if (inactive_since) {
-        Object.keys(this.routes).map(function (path) {
-            var route = that.routes[path];
+        Object.keys(this._routes.getAll()).map(function (path) {
+            var route = that._routes.get(path);
             if (route.last_activity < inactive_since) {
                 routes[path] = route;
             }
         });
     } else {
-        routes = this.routes;
+        routes = this._routes.getAll();
     }
     res.write(JSON.stringify(routes));
     res.end();
@@ -259,11 +261,11 @@ ConfigurableProxy.prototype.post_routes = function (req, res, path, data) {
 ConfigurableProxy.prototype.delete_routes = function (req, res, path) {
     // DELETE removes an existing route
     log.debug('DELETE', path);
-    if (this.routes[path] === undefined) {
-        res.writeHead(404);
-    } else {
+    if (this._routes.hasRoute(path)) {
         this.remove_route(path);
         res.writeHead(204);
+    } else {
+        res.writeHead(404);
     }
     res.end();
     this.statsd.increment('api.route.delete', 1);
@@ -286,9 +288,9 @@ ConfigurableProxy.prototype.target_for_req = function (req) {
 ConfigurableProxy.prototype.update_last_activity = function (prefix) {
     var timer = this.statsd.createTimer('last_activity_updating');
     // note last activity in routing table
-    if (this.routes[prefix] !== undefined) {
+    if (this._routes.hasRoute(prefix)) {
         // route may have been deleted with open connections
-        this.routes[prefix].last_activity = new Date();
+        this._routes.get(prefix).last_activity = new Date();
     }
     timer.stop();
 };

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -17,8 +17,7 @@ var http = require('http'),
     util = require('util'),
     URL = require('url'),
     querystring = require('querystring'),
-    store = require('./store.js'),
-    trie = require('./trie.js');
+    store = require('./store.js');
 
 function bound (that, method) {
     // bind a method, to ensure `this=that` when it is called
@@ -103,7 +102,6 @@ function ConfigurableProxy (options) {
     this.options = options || {};
 
     this._routes = store.MemoryStore();
-    this.trie = new trie.URLTrie();
     this.auth_token = this.options.auth_token;
     this.includePrefix = options.includePrefix === undefined ? true : options.includePrefix;
     this.host_routing = this.options.host_routing;
@@ -189,12 +187,11 @@ util.inherits(ConfigurableProxy, EventEmitter);
 
 ConfigurableProxy.prototype.add_route = function (path, data) {
     // add a route to the routing table
-    path = trie.trim_prefix(path);
+    path = this._routes.cleanPath(path);
     if (this.host_routing && path !== '/') {
         data.host = path.split('/')[1];
     }
     this._routes.add(path, data);
-    this.trie.add(path, data);
     this.update_last_activity(path);
 };
 
@@ -202,7 +199,6 @@ ConfigurableProxy.prototype.remove_route = function (path) {
     // remove a route from the routing table
     if (this._routes.hasRoute(path)) {
         this._routes.remove(path);
-        this.trie.remove(path);
     }
 };
 
@@ -275,7 +271,7 @@ ConfigurableProxy.prototype.target_for_req = function (req) {
     var timer = this.statsd.createTimer('find_target_for_req');
     // return proxy target for a given url path
     var base_path = (this.host_routing) ? '/' + parse_host(req) : '';
-    var route = this.trie.get(trie.string_to_path(base_path + decodeURIComponent(req.url)));
+    var route = this._routes.getTarget(base_path + decodeURIComponent(req.url));
     timer.stop();
     if (route) {
         return {

--- a/lib/store.js
+++ b/lib/store.js
@@ -9,61 +9,73 @@ var NotImplemented = function (name) {
 
 var BaseStore = Object.create(Object.prototype, {
   // "abstract" methods
-  get:       { value: function (path) { throw NotImplemented("get"); } },
-  getTarget: { value: function (path) { throw NotImplemented("getTarget"); } },
-  getAll:    { value: function (path) { throw NotImplemented("getAll"); } },
-  add:       { value: function (path) { throw NotImplemented("add"); } },
-  update:    { value: function (path) { throw NotImplemented("update"); } },
-  remove:    { value: function (path) { throw NotImplemented("remove"); } },
-  hasRoute:  { value: function (path) { throw NotImplemented("hasRoute"); } },
+  get:       { value: function () { throw NotImplemented("get"); } },
+  getTarget: { value: function () { throw NotImplemented("getTarget"); } },
+  getAll:    { value: function () { throw NotImplemented("getAll"); } },
+  add:       { value: function () { throw NotImplemented("add"); } },
+  update:    { value: function () { throw NotImplemented("update"); } },
+  remove:    { value: function () { throw NotImplemented("remove"); } },
+  hasRoute:  { value: function () { throw NotImplemented("hasRoute"); } },
 
   cleanPath: {
     value: function (path) {
       return trie.trim_prefix(path);
+    }
+  },
+
+  notify: {
+    value: function (cb) {
+      if (typeof(cb) === "function") {
+        var args = Array.prototype.slice.call(arguments, 1);
+        cb.apply(this, args);
+      }
     }
   }
 });
 
 function MemoryStore () {
   var routes = {};
-  var urls   = new trie.URLTrie()
+  var urls   = new trie.URLTrie();
 
   return Object.create(BaseStore, {
     get: {
-      value: function (path) {
-        return routes[path];
+      value: function (path, cb) {
+        this.notify(cb, routes[path]);
       }
     },
     getTarget: {
-      value: function (path) {
-        return urls.get(path);
+      value: function (path, cb) {
+        this.notify(cb, urls.get(path));
       }
     },
     getAll: {
-      value: function () {
-        return routes;
+      value: function (cb) {
+        this.notify(cb, routes);
       }
     },
     add: {
-      value: function (path, data) {
+      value: function (path, data, cb) {
         routes[path] = data;
         urls.add(path, data);
+        this.notify(cb);
       }
     },
     update: {
-      value: function (path, data) {
+      value: function (path, data, cb) {
         Object.assign(routes[path], data);
+        this.notify(cb);
       }
     },
     remove: {
-      value: function (path) {
+      value: function (path, cb) {
         delete routes[path];
         urls.remove(path);
+        this.notify(cb);
       }
     },
     hasRoute: {
-      value: function (path) {
-        return routes.hasOwnProperty(path);
+      value: function (path, cb) {
+        this.notify(cb, routes.hasOwnProperty(path));
       }
     }
   });

--- a/lib/store.js
+++ b/lib/store.js
@@ -5,6 +5,7 @@ function MemoryStore () {
     get: function (path) { return routes[path]; },
     getAll: function () { return routes; },
     add: function (path, data) { routes[path] = data; },
+    update: function(path, data) { Object.assign(routes[path], data) },
     remove: function (path) { delete routes[path]; },
     hasRoute: function (path) { return routes.hasOwnProperty(path); }
   };

--- a/lib/store.js
+++ b/lib/store.js
@@ -62,12 +62,7 @@ function MemoryStore () {
     },
     update: {
       value: function (path, data, cb) {
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-                routes[path][key] = data[key];
-            }
-        }
-
+        Object.assign(routes[path], data);
         this.notify(cb);
       }
     },

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,12 +1,23 @@
+var trie = require("./trie.js");
+
 function MemoryStore () {
   var routes = {};
+  var urls   = new trie.URLTrie()
 
   return {
     get: function (path) { return routes[path]; },
+    getTarget: function(path) { return urls.get(path); },
     getAll: function () { return routes; },
-    add: function (path, data) { routes[path] = data; },
+    cleanPath: function(path) { return trie.trim_prefix(path); },
+    add: function (path, data) {
+      routes[path] = data;
+      urls.add(path, data);
+    },
     update: function(path, data) { Object.assign(routes[path], data) },
-    remove: function (path) { delete routes[path]; },
+    remove: function (path) {
+      delete routes[path];
+      urls.remove(path);
+    },
     hasRoute: function (path) { return routes.hasOwnProperty(path); }
   };
 }

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,25 +1,72 @@
 var trie = require("./trie.js");
 
+var NotImplemented = function (name) {
+  return {
+    name: "NotImplementedException",
+    message: "method '" + name + "' not implemented"
+  };
+};
+
+var BaseStore = Object.create(Object.prototype, {
+  // "abstract" methods
+  get:       { value: function (path) { throw NotImplemented("get"); } },
+  getTarget: { value: function (path) { throw NotImplemented("getTarget"); } },
+  getAll:    { value: function (path) { throw NotImplemented("getAll"); } },
+  add:       { value: function (path) { throw NotImplemented("add"); } },
+  update:    { value: function (path) { throw NotImplemented("update"); } },
+  remove:    { value: function (path) { throw NotImplemented("remove"); } },
+  hasRoute:  { value: function (path) { throw NotImplemented("hasRoute"); } },
+
+  cleanPath: {
+    value: function (path) {
+      return trie.trim_prefix(path);
+    }
+  }
+});
+
 function MemoryStore () {
   var routes = {};
   var urls   = new trie.URLTrie()
 
-  return {
-    get: function (path) { return routes[path]; },
-    getTarget: function(path) { return urls.get(path); },
-    getAll: function () { return routes; },
-    cleanPath: function(path) { return trie.trim_prefix(path); },
-    add: function (path, data) {
-      routes[path] = data;
-      urls.add(path, data);
+  return Object.create(BaseStore, {
+    get: {
+      value: function (path) {
+        return routes[path];
+      }
     },
-    update: function(path, data) { Object.assign(routes[path], data) },
-    remove: function (path) {
-      delete routes[path];
-      urls.remove(path);
+    getTarget: {
+      value: function (path) {
+        return urls.get(path);
+      }
     },
-    hasRoute: function (path) { return routes.hasOwnProperty(path); }
-  };
+    getAll: {
+      value: function () {
+        return routes;
+      }
+    },
+    add: {
+      value: function (path, data) {
+        routes[path] = data;
+        urls.add(path, data);
+      }
+    },
+    update: {
+      value: function (path, data) {
+        Object.assign(routes[path], data);
+      }
+    },
+    remove: {
+      value: function (path) {
+        delete routes[path];
+        urls.remove(path);
+      }
+    },
+    hasRoute: {
+      value: function (path) {
+        return routes.hasOwnProperty(path);
+      }
+    }
+  });
 }
 
 exports.MemoryStore = MemoryStore;

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,0 +1,13 @@
+function MemoryStore () {
+  var routes = {};
+
+  return {
+    get: function (path) { return routes[path]; },
+    getAll: function () { return routes; },
+    add: function (path, data) { routes[path] = data; },
+    remove: function (path) { delete routes[path]; },
+    hasRoute: function (path) { return routes.hasOwnProperty(path); }
+  };
+}
+
+exports.MemoryStore = MemoryStore;

--- a/lib/store.js
+++ b/lib/store.js
@@ -62,7 +62,12 @@ function MemoryStore () {
     },
     update: {
       value: function (path, data, cb) {
-        Object.assign(routes[path], data);
+        for (var key in data) {
+            if (data.hasOwnProperty(key)) {
+                routes[path][key] = data[key];
+            }
+        }
+
         this.notify(cb);
       }
     },

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -8,7 +8,7 @@ var configproxy = require('../lib/configproxy');
 
 var servers = [];
 
-var add_target = exports.add_target = function (proxy, path, port, websocket, target_path) {
+var add_target = exports.add_target = function (proxy, path, port, websocket, target_path, cb) {
     var target = 'http://127.0.0.1:' + port;
     if (target_path) {
         target = target + target_path;
@@ -41,7 +41,7 @@ var add_target = exports.add_target = function (proxy, path, port, websocket, ta
     }
     server.listen(port);
     servers.push(server);
-    proxy.add_route(path, {target: target});
+    proxy.add_route(path, {target: target}, cb);
 };
 
 var add_target_redirecting = exports.add_target_redirecting = function (proxy, path, port, target_path, redirect_to) {
@@ -51,36 +51,46 @@ var add_target_redirecting = exports.add_target_redirecting = function (proxy, p
     if (target_path) {
         target = target + target_path;
     }
-    var server;
-    server = http.createServer(function (req, res) {
-        res.setHeader("Location", redirect_to);
-        res.statusCode = 301;
-        res.write('');
-        res.end();
+
+    proxy.add_route(path, { target: target }, function (route) {
+        var server = http.createServer(function (req, res) {
+            res.setHeader("Location", redirect_to);
+            res.statusCode = 301;
+            res.write('');
+            res.end();
+        });
+
+        server.listen(port);
+        servers.push(server);
     });
-    server.listen(port);
-    servers.push(server);
-    proxy.add_route(path, {target: target});
 };
+
+function add_targets (proxy, paths, port, callback) {
+    var remainingPaths = paths.length;
+    if (remainingPaths === 0) {
+      callback();
+      return;
+    }
+
+    paths.forEach(function (path) {
+        add_target(proxy, path, ++port, true, null, function () {
+            if (--remainingPaths === 0) {
+              callback();
+            }
+        });
+    });
+}
 
 exports.setup_proxy = function (port, callback, options, paths) {
     options = options || {};
     options.auth_token = 'secret';
+
     var proxy = new configproxy.ConfigurableProxy(options);
-    // add default route
-    var p = port + 1;
-    paths = paths || ['/'];
-    paths.map(function (path) {
-        p = p + 1;
-        add_target(proxy, path, p, true);
-    });
-
     var ip = '127.0.0.1';
-
     var countdown = 2;
+
     var onlisten = function () {
-        countdown = countdown - 1;
-        if (countdown === 0) {
+        if (--countdown === 0) {
             if (callback) {
                 callback(proxy);
             }
@@ -88,14 +98,14 @@ exports.setup_proxy = function (port, callback, options, paths) {
     };
 
     if (options.error_target) {
-        countdown = countdown + 1;
+        countdown++;
         var error_server = http.createServer(function (req, res) {
             var parsed = URL.parse(req.url);
             var query = querystring.parse(parsed.query);
             res.setHeader('Content-Type', 'text/plain');
-            res.write(query.url);
             req.on('data', function () {});
             req.on('end', function () {
+                res.write(query.url);
                 res.end();
             });
         });
@@ -104,13 +114,15 @@ exports.setup_proxy = function (port, callback, options, paths) {
         servers.push(error_server);
     }
 
-    proxy.proxy_server.listen(port, ip);
-    proxy.api_server.listen(port + 1, ip);
     servers.push(proxy.proxy_server);
     servers.push(proxy.api_server);
     proxy.api_server.on('listening', onlisten);
     proxy.proxy_server.on('listening', onlisten);
-    return proxy;
+
+    add_targets(proxy, paths || ["/"], port + 1, function () {
+        proxy.proxy_server.listen(port, ip);
+        proxy.api_server.listen(port + 1, ip);
+    });
 };
 
 exports.teardown_servers = function (callback) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "files": [
     "index.js",
     "lib/configproxy.js",
+    "lib/store.js",
     "lib/trie.js",
     "lib/error/*.html",
     "bin/configurable-http-proxy"

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -181,16 +181,31 @@ describe("API Tests", function () {
         var port = 8998;
         var path = '/yesterday';
 
-        var now           = new Date();
-        var yesterday     = new Date(now.getTime() - (24 * 3.6e6));
-        var long_ago      = new Date(1);
-        var hour_ago      = new Date(now.getTime() - 3.6e6);
+        var now = new Date();
+        var yesterday = new Date(now.getTime() - (24 * 3.6e6));
+        var long_ago = new Date(1);
+        var hour_ago = new Date(now.getTime() - 3.6e6);
         var hour_from_now = new Date(now.getTime() + 3.6e6);
 
         var tests = [
-            { name: 'long ago', since: long_ago, expected: {} },
-            { name: 'an hour ago', since: hour_ago, expected: { '/yesterday': true } },
-            { name: 'the future', since: hour_from_now, expected: { '/yesterday': true, '/today': true } }
+            {
+                name: 'long ago',
+                since: long_ago,
+                expected: {}
+            },
+            {
+                name: 'an hour ago',
+                since: hour_ago,
+                expected: {'/yesterday': true}
+            },
+            {
+                name: 'the future',
+                since: hour_from_now,
+                expected: {
+                    '/yesterday': true,
+                    '/today': true
+                }
+            }
         ];
 
         var seen = 0;

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -25,35 +25,50 @@ describe("API Tests", function () {
             });
             callback();
         }
-        proxy = util.setup_proxy(port, setup_r);
+
+        util.setup_proxy(port, function (new_proxy) {
+            proxy = new_proxy;
+            setup_r();
+        });
     });
 
     afterEach(function (callback) {
         util.teardown_servers(callback);
     });
 
-    it("Basic proxy constructor", function () {
+    it("Basic proxy constructor", function (done) {
         expect(proxy).toBeDefined();
         expect(proxy.default_target).toBe(undefined);
-        expect(proxy.target_for_req({url: '/'})).toEqual({
-            prefix: '/',
-            target: "http://127.0.0.1:" + (port + 2)
+
+        proxy.target_for_req({ url: "/" }, function (route) {
+            expect(route).toEqual({
+                prefix: "/",
+                target: "http://127.0.0.1:" + (port + 2)
+            });
+
+            done();
         });
     });
 
-    it("Default target is used for /any/random/url", function () {
-        var target = proxy.target_for_req({url: '/any/random/url'});
-        expect(target).toEqual({
-            prefix: '/',
-            target: "http://127.0.0.1:" + (port + 2)
+    it("Default target is used for /any/random/url", function (done) {
+        proxy.target_for_req({ url: "/any/random/url" }, function (target) {
+            expect(target).toEqual({
+                prefix: "/",
+                target: "http://127.0.0.1:" + (port + 2)
+            });
+
+            done();
         });
     });
 
-    it("Default target is used for /", function () {
-        var target = proxy.target_for_req({url: '/'});
-        expect(target).toEqual({
-            prefix: '/',
-            target: "http://127.0.0.1:" + (port + 2)
+    it("Default target is used for /", function (done) {
+        proxy.target_for_req({ url: "/" }, function (target) {
+            expect(target).toEqual({
+                prefix: "/",
+                target: "http://127.0.0.1:" + (port + 2)
+            });
+
+            done();
         });
     });
 
@@ -72,6 +87,7 @@ describe("API Tests", function () {
     it("POST /api/routes[/path] creates a new route", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
+
         r.post({
             url: api_url + '/user/foo',
             body: JSON.stringify({target: target}),
@@ -79,10 +95,12 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy._routes.get('/user/foo');
-            expect(route.target).toEqual(target);
-            expect(typeof route.last_activity).toEqual('object');
-            done();
+
+            proxy._routes.get('/user/foo', function (route) {
+                expect(route.target).toEqual(target);
+                expect(typeof route.last_activity).toEqual('object');
+                done();
+            });
         });
     });
 
@@ -96,12 +114,16 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy._routes.get('/user/foo@bar');
-            expect(route.target).toEqual(target);
-            expect(typeof route.last_activity).toEqual('object');
-            route = proxy.target_for_req({url: '/user/foo@bar/path'});
-            expect(route.target).toEqual(target);
-            done();
+
+            proxy._routes.get('/user/foo@bar', function (route) {
+                expect(route.target).toEqual(target);
+                expect(typeof route.last_activity).toEqual('object');
+
+                proxy.target_for_req({ url: "/user/foo@bar/path" }, function (proxy_target) {
+                    expect(proxy_target.target).toEqual(target);
+                    done();
+                });
+            });
         });
     });
 
@@ -115,10 +137,12 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy._routes.get('/');
-            expect(route.target).toEqual(target);
-            expect(typeof route.last_activity).toEqual('object');
-            done();
+
+            proxy._routes.get("/", function (route) {
+                expect(route.target).toEqual(target);
+                expect(typeof route.last_activity).toEqual('object');
+                done();
+            });
         });
     });
 
@@ -126,13 +150,29 @@ describe("API Tests", function () {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;
         var path = '/user/bar';
-        util.add_target(proxy, path, port);
-        expect(proxy._routes.get(path).target).toEqual(target);
-        r.del(api_url + path, function (error, res, body) {
+
+        util.add_target(proxy, path, port, null, null, function () {
+            proxy._routes.get(path, function (route) {
+                expect(route.target).toEqual(target);
+
+                r.del(api_url + path, function (error, res, body) {
+                    expect(error).toBe(null);
+                    expect(res.statusCode).toEqual(204);
+                    expect(res.body).toEqual('');
+
+                    proxy._routes.get(path, function (deleted_route) {
+                        expect(deleted_route).toBe(undefined);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it("GET /api/routes?inactive_since= with bad value returns a 400", function (done) {
+        r.get(api_url + "?inactive_since=endoftheuniverse", function (error, res, body) {
             expect(error).toBe(null);
-            expect(res.statusCode).toEqual(204);
-            expect(res.body).toEqual('');
-            expect(proxy._routes.get(path)).toBe(undefined);
+            expect(res.statusCode).toEqual(400);
             done();
         });
     });
@@ -140,44 +180,18 @@ describe("API Tests", function () {
     it("GET /api/routes?inactive_since= filters inactive entries", function (done) {
         var port = 8998;
         var path = '/yesterday';
-        util.add_target(proxy, '/yesterday', port);
-        util.add_target(proxy, '/today', port+1);
 
-        var now = new Date();
-        var yesterday = new Date(now.getTime() - (24 * 3.6e6));
-        var long_ago = new Date(1);
-        var hour_ago = new Date(now.getTime() - 3.6e6);
+        var now           = new Date();
+        var yesterday     = new Date(now.getTime() - (24 * 3.6e6));
+        var long_ago      = new Date(1);
+        var hour_ago      = new Date(now.getTime() - 3.6e6);
         var hour_from_now = new Date(now.getTime() + 3.6e6);
 
-        proxy.remove_route('/');
-
-        proxy._routes.get('/yesterday').last_activity = yesterday;
-
         var tests = [
-            {
-                name: 'long ago',
-                since: long_ago,
-                expected: {},
-            },
-            {
-                name: 'an hour ago',
-                since: hour_ago,
-                expected: {'/yesterday': true},
-            },
-            {
-                name: 'the future',
-                since: hour_from_now,
-                expected: {
-                    '/yesterday': true,
-                    '/today': true
-                },
-            },
+            { name: 'long ago', since: long_ago, expected: {} },
+            { name: 'an hour ago', since: hour_ago, expected: { '/yesterday': true } },
+            { name: 'the future', since: hour_from_now, expected: { '/yesterday': true, '/today': true } }
         ];
-
-        r.get(api_url + "?inactive_since=endoftheuniverse", function (error, res, body) {
-            expect(error).toBe(null);
-            expect(res.statusCode).toEqual(400);
-        });
 
         var seen = 0;
         var do_req = function (i) {
@@ -185,21 +199,21 @@ describe("API Tests", function () {
             r.get(api_url + '?inactive_since=' + t.since.toISOString(), function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
-                var routes = JSON.parse(res.body);
-                var route_keys = Object.keys(routes);
+
+                var routes        = JSON.parse(res.body);
+                var route_keys    = Object.keys(routes);
                 var expected_keys = Object.keys(t.expected);
-                var key;
-                Object.keys(routes).map(function (key) {
+
+                route_keys.forEach(function (key) {
                     // check that all routes are expected
                     expect(expected_keys).toContain(key);
                 });
-                Object.keys(t.expected).map(function (key) {
+
+                expected_keys.forEach(function (key) {
                     // check that all expected routes are found
                     expect(route_keys).toContain(key);
-                    expect(routes[key].last_activity).toEqual(
-                        proxy._routes.get(key).last_activity.toISOString()
-                    );
                 });
+
                 seen += 1;
                 if (seen === tests.length) {
                     done();
@@ -209,6 +223,14 @@ describe("API Tests", function () {
             });
         };
 
-        do_req(0);
+        proxy.remove_route("/", function () {
+            util.add_target(proxy, '/yesterday', port, null, null, function () {
+                util.add_target(proxy, '/today', port + 1, null, null, function () {
+                    proxy._routes.update('/yesterday', { last_activity: yesterday }, function () {
+                        do_req(0);
+                    });
+                });
+            });
+        });
     });
 });

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -79,7 +79,7 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy.routes['/user/foo'];
+            var route = proxy._routes.get('/user/foo');
             expect(route.target).toEqual(target);
             expect(typeof route.last_activity).toEqual('object');
             done();
@@ -96,7 +96,7 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy.routes['/user/foo@bar'];
+            var route = proxy._routes.get('/user/foo@bar');
             expect(route.target).toEqual(target);
             expect(typeof route.last_activity).toEqual('object');
             route = proxy.target_for_req({url: '/user/foo@bar/path'});
@@ -115,7 +115,7 @@ describe("API Tests", function () {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(201);
             expect(res.body).toEqual('');
-            var route = proxy.routes['/'];
+            var route = proxy._routes.get('/');
             expect(route.target).toEqual(target);
             expect(typeof route.last_activity).toEqual('object');
             done();
@@ -127,12 +127,12 @@ describe("API Tests", function () {
         var target = 'http://127.0.0.1:' + port;
         var path = '/user/bar';
         util.add_target(proxy, path, port);
-        expect(proxy.routes[path].target).toEqual(target);
+        expect(proxy._routes.get(path).target).toEqual(target);
         r.del(api_url + path, function (error, res, body) {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(204);
             expect(res.body).toEqual('');
-            expect(proxy.routes[path]).toBe(undefined);
+            expect(proxy._routes.get(path)).toBe(undefined);
             done();
         });
     });
@@ -151,7 +151,7 @@ describe("API Tests", function () {
 
         proxy.remove_route('/');
 
-        proxy.routes['/yesterday'].last_activity = yesterday;
+        proxy._routes.get('/yesterday').last_activity = yesterday;
 
         var tests = [
             {
@@ -197,7 +197,7 @@ describe("API Tests", function () {
                     // check that all expected routes are found
                     expect(route_keys).toContain(key);
                     expect(routes[key].last_activity).toEqual(
-                        proxy.routes[key].last_activity.toISOString()
+                        proxy._routes.get(key).last_activity.toISOString()
                     );
                 });
                 seen += 1;

--- a/test/jasmine.json
+++ b/test/jasmine.json
@@ -1,6 +1,5 @@
 {
   "spec_dir": "test",
   "stopSpecOnExpectationFailure": false,
-  "random": false,
   "spec_files": ["*spec.js"]
 }

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -169,7 +169,7 @@ describe("Proxy Tests", function () {
       };
 
       var cp = new ConfigurableProxy(options);
-      expect(cp.routes['/'].target).toEqual('http://127.0.0.1:9001');
+      expect(cp._routes.get('/').target).toEqual('http://127.0.0.1:9001');
     });
 
     it("includePrefix: false + prependPath: false", function (done) {
@@ -266,7 +266,7 @@ describe("Proxy Tests", function () {
         r(proxy_url + '/external/urlpath/rest/of/it', function (error, res, body) {
             expect(error).toBe(null);
             expect(res.statusCode).toEqual(301);
-            expect(res.headers.location).toEqual(redirect_to); 
+            expect(res.headers.location).toEqual(redirect_to);
             done();
         });
     });

--- a/test/store_spec.js
+++ b/test/store_spec.js
@@ -19,6 +19,16 @@ describe("MemoryStore", function () {
     });
   });
 
+  describe("getTarget", function () {
+    it("returns the target object for the path", function () {
+      this.subject.add("/my_route", { "target": "http://localhost:8213" });
+
+      var target = this.subject.getTarget("/my_route");
+      expect(target.prefix).toEqual("/my_route");
+      expect(target.data.target).toEqual("http://localhost:8213");
+    });
+  });
+
   describe("getAll", function () {
     it("returns all routes", function () {
       this.subject.add("/my_route", { "test": "value1" });

--- a/test/store_spec.js
+++ b/test/store_spec.js
@@ -8,10 +8,13 @@ describe("MemoryStore", function () {
   });
 
   describe("get", function () {
-    it("returns the data for the specified path", function () {
+    it("returns the data for the specified path", function (done) {
       this.subject.add("/my_route", { "test": "value" });
 
-      expect(this.subject.get("/my_route")).toEqual({ "test": "value" });
+      this.subject.get("/my_route", function (data) {
+        expect(data).toEqual({ "test": "value" });
+        done();
+      });
     });
 
     it("returns undefined when not found", function () {
@@ -20,85 +23,103 @@ describe("MemoryStore", function () {
   });
 
   describe("getTarget", function () {
-    it("returns the target object for the path", function () {
+    it("returns the target object for the path", function (done) {
       this.subject.add("/my_route", { "target": "http://localhost:8213" });
 
-      var target = this.subject.getTarget("/my_route");
-      expect(target.prefix).toEqual("/my_route");
-      expect(target.data.target).toEqual("http://localhost:8213");
+      this.subject.getTarget("/my_route", function (target) {
+        expect(target.prefix).toEqual("/my_route");
+        expect(target.data.target).toEqual("http://localhost:8213");
+        done();
+      });
     });
   });
 
   describe("getAll", function () {
-    it("returns all routes", function () {
+    it("returns all routes", function (done) {
       this.subject.add("/my_route", { "test": "value1" });
       this.subject.add("/my_other_route", { "test": "value2" });
 
-      var routes = this.subject.getAll();
-      expect(Object.keys(routes).length).toEqual(2);
-      expect(routes["/my_route"]).toEqual({ "test": "value1" });
-      expect(routes["/my_other_route"]).toEqual({ "test": "value2" });
+      this.subject.getAll(function (routes) {
+        expect(Object.keys(routes).length).toEqual(2);
+        expect(routes["/my_route"]).toEqual({ "test": "value1" });
+        expect(routes["/my_other_route"]).toEqual({ "test": "value2" });
+        done();
+      });
     });
 
-    it("returns a blank object when no routes defined", function () {
-      expect(this.subject.getAll()).toEqual({});
+    it("returns a blank object when no routes defined", function (done) {
+      this.subject.getAll(function (routes) {
+        expect(routes).toEqual({});
+        done();
+      });
     });
   });
 
   describe("add", function () {
-    it("adds data to the store for the specified path", function () {
+    it("adds data to the store for the specified path", function (done) {
       this.subject.add("/my_route", { "test": "value" });
 
-      expect(this.subject.get("/my_route")).toEqual({ "test": "value" });
+      this.subject.get("/my_route", function (route) {
+        expect(route).toEqual({ "test": "value" });
+        done();
+      });
     });
 
-    it("overwrites any existing values", function () {
+    it("overwrites any existing values", function (done) {
       this.subject.add("/my_route", { "test": "value" });
       this.subject.add("/my_route", { "test": "updatedValue" });
 
-      expect(this.subject.get("/my_route")).toEqual({ "test": "updatedValue" });
+      this.subject.get("/my_route", function (route) {
+        expect(route).toEqual({ "test": "updatedValue" });
+        done();
+      });
     });
   });
 
   describe("update", function () {
-    it("merges supplied data with existing data", function () {
+    it("merges supplied data with existing data", function (done) {
       this.subject.add("/my_route", { "version": 1, "test": "value" });
       this.subject.update("/my_route", { "version": 2 });
 
-      var route = this.subject.get("/my_route");
-      expect(route["version"]).toEqual(2);
-      expect(route["test"]).toEqual("value");
-    });
-
-    it("throws an error when the route doesn't exist", function () {
-      var subject = this.subject;
-
-      expect(function() { subject.update("/my_route", { "test": "value" }) }).toThrow();
+      this.subject.get("/my_route", function (route) {
+        expect(route.version).toEqual(2);
+        expect(route.test).toEqual("value");
+        done();
+      });
     });
   });
 
   describe("remove", function () {
-    it("removes a route from the table", function () {
+    it("removes a route from the table", function (done) {
       this.subject.add("/my_route", { "test": "value" });
       this.subject.remove("/my_route");
 
-      expect(this.subject.get("/my_route")).toBe(undefined);
+      this.subject.get("/my_route", function (route) {
+        expect(route).toBe(undefined);
+        done();
+      });
     });
 
-    it("doesn't explode when route is not defined", function () {
+    it("doesn't explode when route is not defined", function (done) {
       // would blow up if an error was thrown
-      this.subject.remove("/my_route");
+      this.subject.remove("/my_route", done);
     });
   });
 
   describe("hasRoute", function () {
-    it("returns false when the path is not found", function () {
+    it("returns false when the path is not found", function (done) {
       this.subject.add("/my_route", { "test": "value" });
-      expect(this.subject.hasRoute("/my_route")).toBe(true)
+      this.subject.hasRoute("/my_route", function (result) {
+        expect(result).toBe(true);
+        done();
+      });
     });
 
-    it("returns false when the path is not found", function () {
-      expect(this.subject.hasRoute("/wut")).toBe(false)
+    it("returns false when the path is not found", function (done) {
+      this.subject.hasRoute("/wut", function (result) {
+        expect(result).toBe(false);
+        done();
+      });
     });
   });
 });

--- a/test/store_spec.js
+++ b/test/store_spec.js
@@ -1,0 +1,83 @@
+// jshint jasmine: true
+
+var store = require("../lib/store.js");
+
+describe("MemoryStore", function () {
+  beforeEach(function () {
+    this.subject = store.MemoryStore();
+  });
+
+  describe("routes", function () {
+    it("creates an empty routes object", function () {
+      expect(this.subject.getAll()).toEqual({});
+    });
+  });
+
+  describe("get", function () {
+    it("returns the data for the specified path", function () {
+      this.subject.add("/my_route", { "test": "value" });
+
+      expect(this.subject.get("/my_route")).toEqual({ "test": "value" });
+    });
+
+    it("returns undefined when not found", function () {
+      expect(this.subject.get("/wut")).toBe(undefined);
+    });
+  });
+
+  describe("getAll", function () {
+    it("returns all routes", function () {
+      this.subject.add("/my_route", { "test": "value1" });
+      this.subject.add("/my_other_route", { "test": "value2" });
+
+      var routes = this.subject.getAll();
+      expect(Object.keys(routes).length).toEqual(2);
+      expect(routes["/my_route"]).toEqual({ "test": "value1" });
+      expect(routes["/my_other_route"]).toEqual({ "test": "value2" });
+    });
+
+    it("returns a blank object when no routes defined", function () {
+      expect(this.subject.getAll()).toEqual({});
+    });
+  });
+
+  describe("add", function () {
+    it("adds data to the store for the specified path", function () {
+      this.subject.add("/my_route", { "test": "value" });
+
+      expect(this.subject.get("/my_route")).toEqual({ "test": "value" });
+    });
+
+    it("overwrites any existing values", function () {
+      this.subject.add("/my_route", { "test": "value" });
+      this.subject.add("/my_route", { "test": "updatedValue" });
+
+      expect(this.subject.get("/my_route")).toEqual({ "test": "updatedValue" });
+    });
+  });
+
+  describe("remove", function () {
+    it("removes a route from the table", function () {
+      this.subject.add("/my_route", { "test": "value" });
+      this.subject.remove("/my_route");
+
+      expect(this.subject.get("/my_route")).toBe(undefined);
+    });
+
+    it("doesn't explode when route is not defined", function () {
+      // would blow up if an error was thrown
+      this.subject.remove("/my_route");
+    });
+  });
+
+  describe("hasRoute", function () {
+    it("returns false when the path is not found", function () {
+      this.subject.add("/my_route", { "test": "value" });
+      expect(this.subject.hasRoute("/my_route")).toBe(true)
+    });
+
+    it("returns false when the path is not found", function () {
+      expect(this.subject.hasRoute("/wut")).toBe(false)
+    });
+  });
+});

--- a/test/store_spec.js
+++ b/test/store_spec.js
@@ -7,12 +7,6 @@ describe("MemoryStore", function () {
     this.subject = store.MemoryStore();
   });
 
-  describe("routes", function () {
-    it("creates an empty routes object", function () {
-      expect(this.subject.getAll()).toEqual({});
-    });
-  });
-
   describe("get", function () {
     it("returns the data for the specified path", function () {
       this.subject.add("/my_route", { "test": "value" });
@@ -53,6 +47,23 @@ describe("MemoryStore", function () {
       this.subject.add("/my_route", { "test": "updatedValue" });
 
       expect(this.subject.get("/my_route")).toEqual({ "test": "updatedValue" });
+    });
+  });
+
+  describe("update", function () {
+    it("merges supplied data with existing data", function () {
+      this.subject.add("/my_route", { "version": 1, "test": "value" });
+      this.subject.update("/my_route", { "version": 2 });
+
+      var route = this.subject.get("/my_route");
+      expect(route["version"]).toEqual(2);
+      expect(route["test"]).toEqual("value");
+    });
+
+    it("throws an error when the route doesn't exist", function () {
+      var subject = this.subject;
+
+      expect(function() { subject.update("/my_route", { "test": "value" }) }).toThrow();
     });
   });
 


### PR DESCRIPTION
@minrk 

# The Problem

Currently the code that handles persistence of routes is embedded directly in the proxy code. This makes it difficult to choose a different storage method (e.g. redis, memcached, db, etc.).

This issue becomes apparent when you're running multiple JupyterHub instances behind nginx (or some other proxy). In this scenario, each JH instance will spawn their own proxy and maintain their own route table (in the node proc).

When a request comes in at `/user/xyz`, depending on the host that nginx routes to, the local proxy will either have the route, or not. 

😢 

Initially I patched the JH Proxy object to update all routes and lowered the last_activity_timeout param so it would happen often, but this seemed like a total hack and doesn't always work (still a small window of time where the error can occur).

# The Solution

Ideally, storage should be configurable/pluggable. I'm thinking something like passing a config option to change the persistence method or something.

In order to keep this PR small and reviewable, I've simply moved the storage from `configproxy.js` into it's own `store.js` module. The trie is still used, and all storage is still in memory (i.e. nothing changes).

# Next Steps

If this seems reasonable, then I'll add implementations for other providers in a separate PR.