### PR TITLE
Only support LTS and greater releases of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "5"
   - "4"
   - "0.12"
-  - "0.11"
-  - "0.10"
 install:
   - npm install -g codecov
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
+  - "6"
   - "5"
   - "4"
-  - "0.12"
 install:
   - npm install -g codecov
   - npm install


### PR DESCRIPTION
To use newer features of JavaScript and Node.js that are useful _and_ performant (like native `Object.assign`, built-in `Map`), we should stick to more recent versions of Node.