### PR TITLE
query string is an object, but also not an object, on node6

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -211,7 +211,8 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
     var inactive_since = null;
     if (parsed.query) {
         var query = querystring.parse(parsed.query);
-        if (query.hasOwnProperty('inactive_since')) {
+        
+        if (query.inactive_since !== undefined) {
             var timestamp = Date.parse(query.inactive_since);
             if (isFinite(timestamp)) {
                 inactive_since = new Date(timestamp);


### PR DESCRIPTION
hasOwnProperty is not defined, even though `typeof q` is object.

This should get tests passing on node 6