### PR TITLE
Bump version: 1.4.0-dev → 2.0.0-dev

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0-dev
+current_version = 2.0.0-dev
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z0-9]+))?
 tag_name = {new_version}
 allow_dirty = True

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-dev",
+  "version": "2.0.0-dev",
   "name": "configurable-http-proxy",
   "description": "A configurable-on-the-fly HTTP Proxy",
   "author": "Jupyter Developers",


### PR DESCRIPTION
now that base required node has moved from 0.10 to 4