### PR TITLE
Add proxy-timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ matching route is found in the proxy table:
     --statsd-port <port>             Port to send statsd statistics to
     --statsd-prefix <prefix>         Prefix to use for statsd statistics
     --log-level <loglevel>           Log level (debug, info, warn, error)
+    --proxy-timeout <n>              Timeout (in millis) when proxy receives no response from target
 ```
 
 

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -49,7 +49,8 @@ args
     .option('--statsd-host <host>', 'Host to send statsd statistics to')
     .option('--statsd-port <port>', 'Port to send statsd statistics to', parseInt)
     .option('--statsd-prefix <prefix>', 'Prefix to use for statsd statistics')
-    .option('--log-level <loglevel>', 'Log level (debug, info, warn, error)', 'info');
+    .option('--log-level <loglevel>', 'Log level (debug, info, warn, error)', 'info')
+    .option('--proxy-timeout <n>', 'Timeout (in millis) when proxy receives no response from target.', parseInt);
 
 args.parse(process.argv);
 
@@ -157,6 +158,7 @@ options.error_path = args.errorPath;
 options.host_routing = args.hostRouting;
 options.auth_token = process.env.CONFIGPROXY_AUTH_TOKEN;
 options.redirectPort = args.redirectPort;
+options.proxyTimeout = args.proxyTimeout;
 
 // statsd options
 if (args.statsdHost) {


### PR DESCRIPTION
http-proxy lib provides a [proxyTimeout option](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L122) that allows us to set a timeout on the outgoing socket connection to the target. This timeout is very effective when the upstream target does not respond within an expected time.

I had wasted a few hours searching for this option. Documenting this option can save others a significant amount of time.