### PR TITLE
Added label system [WIP]

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -230,7 +230,7 @@ ConfigurableProxy.prototype.remove_route = function (path, cb) {
                     var paths = that.labels[data.label];
                     var idx = paths.indexOf(path);
 
-                    if (idx != -1) {
+                    if (idx !== -1) {
                         paths.splice(idx, 1);
                     }
                 }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -104,6 +104,7 @@ function ConfigurableProxy (options) {
     this._routes = store.MemoryStore();
     this.auth_token = this.options.auth_token;
     this.includePrefix = options.includePrefix === undefined ? true : options.includePrefix;
+    this.labels = {};
     this.host_routing = this.options.host_routing;
     this.error_target = options.error_target;
     if (this.error_target && this.error_target.slice(-1) !== '/') {
@@ -145,6 +146,13 @@ function ConfigurableProxy (options) {
             get : bound(this, authorized(this.get_routes)),
             post : json_handler(bound(this, authorized(this.post_routes))),
             'delete' : bound(this, authorized(this.delete_routes))
+        } ],
+        [ /^\/api\/labels\/?$/, {
+            get : bound(this, authorized(this.get_labels)),
+        } ],
+        [ /^\/api\/labels\/?(.*)$/, {
+            get : bound(this, authorized(this.get_label)),
+            'delete' : bound(this, authorized(this.delete_label))
         } ]
     ];
 
@@ -194,6 +202,13 @@ ConfigurableProxy.prototype.add_route = function (path, data, cb) {
 
     var that = this;
 
+    if (data.hasOwnProperty("label")) {
+        if (!(data.label in this.labels)) {
+            this.labels[data.label] = [];
+        }
+        this.labels[data.label].push(path);
+    }
+
     this._routes.add(path, data, function () {
       that.update_last_activity(path, function () {
         if (typeof(cb) === "function") {
@@ -206,10 +221,21 @@ ConfigurableProxy.prototype.add_route = function (path, data, cb) {
 ConfigurableProxy.prototype.remove_route = function (path, cb) {
     // remove a route from the routing table
     var routes = this._routes;
+    var that = this;
 
     routes.hasRoute(path, function (result) {
         if (result) {
-            routes.remove(path, cb);
+            routes.get(path, function (data) {
+                if (data.hasOwnProperty("label") && data.label in that.labels) {
+                    var paths = that.labels[data.label];
+                    var idx = paths.indexOf(path);
+
+                    if (idx != -1) {
+                        paths.splice(idx, 1);
+                    }
+                }
+                routes.remove(path, cb);
+            });
         }
     });
 };
@@ -251,6 +277,42 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
         res.end();
         that.statsd.increment('api.route.get', 1);
     });
+};
+
+ConfigurableProxy.prototype.get_labels = function (req, res) {
+    // GET returns routing table as JSON dict
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.write(JSON.stringify(this.labels));
+    res.end();
+    this.statsd.increment('api.labels.get', 1);
+};
+
+ConfigurableProxy.prototype.get_label = function (req, res, label) {
+    // GET returns routing table as JSON dict
+    if (! (label in this.labels)) {
+        fail(req, res, 404, "Unknown label" );
+        return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.write(JSON.stringify(this.labels[label]));
+    res.end();
+    this.statsd.increment('api.label.get', 1);
+};
+
+ConfigurableProxy.prototype.delete_label = function (req, res, label) {
+    // GET returns routing table as JSON dict
+    if (! (label in this.labels)) {
+        fail(req, res, 404, "Unknown label" );
+        return;
+    }
+    for (var i = 0; i < this.labels[label].length; ++i) {
+        var path = this.labels[label][i];
+        this.remove_route(path);
+    }
+    delete this.labels[label];
+    res.writeHead(204);
+    res.end();
+    this.statsd.increment('api.label.get', 1);
 };
 
 ConfigurableProxy.prototype.post_routes = function (req, res, path, data) {

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -8,7 +8,7 @@ var configproxy = require('../lib/configproxy');
 
 var servers = [];
 
-var add_target = exports.add_target = function (proxy, path, port, websocket, target_path, cb) {
+var add_target = exports.add_target = function (proxy, path, port, websocket, target_path, cb, label) {
     var target = 'http://127.0.0.1:' + port;
     if (target_path) {
         target = target + target_path;
@@ -41,7 +41,14 @@ var add_target = exports.add_target = function (proxy, path, port, websocket, ta
     }
     server.listen(port);
     servers.push(server);
-    proxy.add_route(path, {target: target}, cb);
+    var payload = {
+        target: target
+    };
+    if (label) {
+        payload.label = label;
+    }
+    
+    proxy.add_route(path, payload, cb);
 };
 
 var add_target_redirecting = exports.add_target_redirecting = function (proxy, path, port, target_path, redirect_to) {


### PR DESCRIPTION
This patch adds a label to a setup route, so that we can then use the label to remove routes associated to that label.

Work in progress as I want to hear your feedback (and I'll also have to update the documentation with the new API)