### PR TITLE
Ability to query while extracting a specific data entry

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -19,6 +19,13 @@ var http = require('http'),
     querystring = require('querystring'),
     store = require('./store.js');
 
+var InvalidQuery = function (message) {
+    return {
+        name: "InvalidQuery",
+        message: message
+    };
+};
+
 function bound (that, method) {
     // bind a method, to ensure `this=that` when it is called
     // because prototype languages are bad
@@ -220,29 +227,18 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
     var parsed = URL.parse(req.url);
     var inactive_since = null;
     var query = {};
-    
+
     if (parsed.query) {
         // we have a query. Parse its validity and replace the
         // data with enhanced objects where needed.
-        var q = querystring.parse(parsed.query);
-        
-        Object.keys(q).forEach(function (key) {
-            // we copy the querystring result to a real object.
-            // The querystring result is not an Object and has no 
-            // hasOwnProperty (needed later)
-            query[key] = q[key];
-        });
-        
-        if (query.inactive_since !== undefined) {
-            var timestamp = Date.parse(query.inactive_since);
-            if (isFinite(timestamp)) {
-                query.inactive_since = new Date(timestamp);
-            } else {
-                fail(req, res, 400, "Invalid datestamp '" + query.inactive_since + "' must be ISO8601.");
-                return;
-            }
+        try {
+            query = this._parse_query(parsed.query);
+        } catch (e) {
+            fail(req, res, 400, e.message); 
+            return;
         }
     }
+    
     res.writeHead(200, { 'Content-Type': 'application/json' });
 
     this._routes.getAll(function (routes) {
@@ -509,6 +505,30 @@ ConfigurableProxy.prototype.handle_api_request = function (req, res) {
         }
     }
     fail(req, res, 404);
+};
+
+ConfigurableProxy.prototype._parse_query = function (url_query) {
+    // we have a query. Parse its validity and replace the
+    // data with enhanced objects where needed.
+    var query = {};
+    var q = querystring.parse(url_query);
+
+    Object.keys(q).forEach(function (key) {
+        // we copy the querystring result to a real object.
+        // The querystring result is not an Object and has no 
+        // hasOwnProperty (needed later)
+        query[key] = q[key];
+    });
+
+    if (query.inactive_since !== undefined) {
+        var timestamp = Date.parse(query.inactive_since);
+        if (isFinite(timestamp)) {
+            query.inactive_since = new Date(timestamp);
+        } else {
+            throw InvalidQuery("Invalid datestamp '" + query.inactive_since + "' must be ISO8601.");
+        }
+    }
+    return query; 
 };
 
 exports.ConfigurableProxy = ConfigurableProxy;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -227,6 +227,9 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
         var q = querystring.parse(parsed.query);
         
         Object.keys(q).forEach(function (key) {
+            // we copy the querystring result to a real object.
+            // The querystring result is not an Object and has no 
+            // hasOwnProperty (needed later)
             query[key] = q[key];
         });
         

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -219,13 +219,21 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
     var that = this;
     var parsed = URL.parse(req.url);
     var inactive_since = null;
+    var query = {};
+    
     if (parsed.query) {
-        var query = querystring.parse(parsed.query);
-
+        // we have a query. Parse its validity and replace the
+        // data with enhanced objects where needed.
+        var q = querystring.parse(parsed.query);
+        
+        Object.keys(q).forEach(function (key) {
+            query[key] = q[key];
+        });
+        
         if (query.inactive_since !== undefined) {
             var timestamp = Date.parse(query.inactive_since);
             if (isFinite(timestamp)) {
-                inactive_since = new Date(timestamp);
+                query.inactive_since = new Date(timestamp);
             } else {
                 fail(req, res, 400, "Invalid datestamp '" + query.inactive_since + "' must be ISO8601.");
                 return;
@@ -236,15 +244,34 @@ ConfigurableProxy.prototype.get_routes = function (req, res) {
 
     this._routes.getAll(function (routes) {
         var results = {};
-
-        if (inactive_since) {
+        if (!query) {
+            // No query to filter on, return the full data.
+            results = routes;
+        } else {
             Object.keys(routes).forEach(function (path) {
-                if (routes[path].last_activity < inactive_since) {
+                var data = routes[path];
+                var add_flag = true;
+                
+                for (var query_key in query) {
+                    if (!query.hasOwnProperty(query_key)) {
+                        continue;
+                    }
+                    
+                    if (query_key === "inactive_since") {
+                        if (data.last_activity >= query.inactive_since) {
+                            add_flag = false;
+                            break;
+                        }
+                    } else if (data[query_key] !== query[query_key]) {
+                        add_flag = false;
+                        break;
+                    }
+                }
+
+                if (add_flag) {
                     results[path] = routes[path];
                 }
             });
-        } else {
-            results = routes;
         }
 
         res.write(JSON.stringify(results));

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -8,7 +8,7 @@ var configproxy = require('../lib/configproxy');
 
 var servers = [];
 
-var add_target = exports.add_target = function (proxy, path, port, websocket, target_path, cb) {
+var add_target = exports.add_target = function (proxy, path, port, websocket, target_path, additional_data, cb) {
     var target = 'http://127.0.0.1:' + port;
     if (target_path) {
         target = target + target_path;
@@ -41,7 +41,7 @@ var add_target = exports.add_target = function (proxy, path, port, websocket, ta
     }
     server.listen(port);
     servers.push(server);
-    proxy.add_route(path, {target: target}, cb);
+    proxy.add_route(path, extend({target: target}, additional_data || {}), cb);
 };
 
 var add_target_redirecting = exports.add_target_redirecting = function (proxy, path, port, target_path, redirect_to) {
@@ -73,7 +73,7 @@ function add_targets (proxy, paths, port, callback) {
     }
 
     paths.forEach(function (path) {
-        add_target(proxy, path, ++port, true, null, function () {
+        add_target(proxy, path, ++port, true, null, null, function () {
             if (--remainingPaths === 0) {
               callback();
             }

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -252,7 +252,7 @@ describe("API Tests", function () {
     it("GET /api/routes?label=foo filters entries", function (done) {
         var port = 8998;
 
-        additional_data = {
+        var additional_data = {
             "label": "foo"
         };
         
@@ -269,10 +269,10 @@ describe("API Tests", function () {
                             expect(route_keys).toContain("/my/url");
                             expect(route_keys).toContain("/my/url2");
                             done();
-                        })
-                    })
-                })
-            })
+                        });
+                    });
+                });
+            });
         });
     });
 });

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -95,7 +95,7 @@ describe("Proxy Tests", function () {
     });
 
     it("target path is prepended by default", function (done) {
-        util.add_target(proxy, '/bar', test_port, false, '/foo', function () {
+        util.add_target(proxy, '/bar', test_port, false, '/foo', null, function () {
             r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -110,7 +110,7 @@ describe("Proxy Tests", function () {
     });
 
     it("handle URI encoding", function (done) {
-        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo', function () {
+        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo', null, function () {
             r(proxy_url + '/b%40r/b%20r/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -125,7 +125,7 @@ describe("Proxy Tests", function () {
     });
 
     it("handle @ in URI same as %40", function (done) {
-        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo', function () {
+        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo', null, function () {
             r(proxy_url + '/b@r/b%20r/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -141,7 +141,7 @@ describe("Proxy Tests", function () {
 
     it("prependPath: false prevents target path from being prepended", function (done) {
         proxy.proxy.options.prependPath = false;
-        util.add_target(proxy, '/bar', test_port, false, '/foo', function () {
+        util.add_target(proxy, '/bar', test_port, false, '/foo', null, function () {
             r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -157,7 +157,7 @@ describe("Proxy Tests", function () {
 
     it("includePrefix: false strips routing prefix from request", function (done) {
         proxy.includePrefix = false;
-        util.add_target(proxy, '/bar', test_port, false, '/foo', function () {
+        util.add_target(proxy, '/bar', test_port, false, '/foo', null, function () {
             r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -186,7 +186,7 @@ describe("Proxy Tests", function () {
     it("includePrefix: false + prependPath: false", function (done) {
         proxy.includePrefix = false;
         proxy.proxy.options.prependPath = false;
-        util.add_target(proxy, '/bar', test_port, false, '/foo', function() {
+        util.add_target(proxy, '/bar', test_port, false, '/foo', null, function() {
             r(proxy_url + '/bar/rest/of/it', function (error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);
@@ -202,7 +202,7 @@ describe("Proxy Tests", function () {
 
     it("hostRouting: routes by host", function(done) {
         proxy.host_routing = true;
-        util.add_target(proxy, '/' + host_test, test_port, false, null, function () {
+        util.add_target(proxy, '/' + host_test, test_port, false, null, null, function () {
             r(host_url + '/some/path', function(error, res, body) {
                 expect(error).toBe(null);
                 expect(res.statusCode).toEqual(200);


### PR DESCRIPTION
Filters the results according to the passed query parameters. With /api/routes/?foo=bar it will extract only those entries whose data contains foo=bar
