### PR TITLE
fix closure reference when serving custom error pages

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -368,7 +368,7 @@ ConfigurableProxy.prototype.handle_proxy_error = function (code, kind, req, res)
         error_request.on('error', function(e) {
             // custom error failed, fallback on default
             log.error("Failed to get custom error page", e);
-            this._handle_proxy_error_default(code, kind, req, res);
+            proxy._handle_proxy_error_default(code, kind, req, res);
         });
         error_request.end();
     } else if (this.error_path) {
@@ -378,7 +378,7 @@ ConfigurableProxy.prototype.handle_proxy_error = function (code, kind, req, res)
             filename = path.join(this.error_path, 'error.html');
             if (!fs.existsSync(filename)) {
                 log.error("No error file %s", filename);
-                this._handle_proxy_error_default(code, kind, req, res);
+                proxy._handle_proxy_error_default(code, kind, req, res);
                 return;
             }
         }


### PR DESCRIPTION
this != that!

cf https://github.com/jupyterhub/jupyterhub/issues/900