### PR TITLE
Clarify ip all-interfaces warning

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -205,7 +205,7 @@ var listen = {};
 listen.port = parseInt(args.port) || 8000;
 if (args.ip === '*') {
     // handle ip=* alias for all interfaces
-    log.warn("Interpreting ip='*' as all-interfaces. Use 0.0.0.0 or ''.");
+    log.warn("Interpreting ip='*' as all-interfaces. Preferred usage is 0.0.0.0 for all IPv4 or '' for all-interfaces.");
     args.ip = '';
 }
 listen.ip = args.ip;


### PR DESCRIPTION
Closes #78 

We could delete the reference to 0.0.0.0 if the warning message seems too long.