### PR TITLE
specify engine requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "request": "~2",
     "ws": "^1.1"
   },
+  "engines": {
+    "node": ">= 4.0"
+  },
+  "engineStrict": true,
   "main": "index.js",
   "files": [
     "index.js",


### PR DESCRIPTION
this should get a better error message on installation with unsupported node versions