### PR TITLE
Alternative Dockerfile-alpine for base image node:alpine

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,11 @@
+FROM node:alpine
+
+EXPOSE 8000
+
+ADD . /srv/configurable-http-proxy
+WORKDIR /srv/configurable-http-proxy
+RUN npm install -g
+
+USER nobody
+
+ENTRYPOINT ["configurable-http-proxy"]


### PR DESCRIPTION
Added alternative Dockerfile-alpine with base image node:alpine instead of actual node:5-slim. The image node:alpine is latest from [official node images](https://hub.docker.com/_/node/), at this time it is node v. 7.9.0. If desirable, Jupyter developers can put the concrete version here (e.g. node:6-alpine). Resulting image for alpine version is   61.1 MB (actual jupyter/configurable-http-proxy size is 209 MB).
Image is already available from docker repository as misolietavec/configurable-http-proxy.

It is not only about size, but also transfer times, security, clarity, minimization of dependencies, etc. I am convinced that for images from jupyter/docker-stacks  it makes sense, too, as an alternative. I have already alpine-based Dockerfile for something roughly comparable to scipy-notebook and use the image on tmpnb service at University of Zilina. The exact equivalent ports of docker-stacks images will be definitively nontrivial, if not impossible :-)