### PR TITLE
Quieter messages for ECONNRESET and ECONNREFUSED

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -389,20 +389,34 @@ class ConfigurableProxy extends EventEmitter {
   _handleProxyErrorDefault(code, kind, req, res) {
     // called when no custom error handler is registered,
     // or is registered and doesn't work
-    if (res.writeHead) res.writeHead(code);
+    if (!res.headersSent && res.writeHead) res.writeHead(code);
     if (res.write) res.write(http.STATUS_CODES[code]);
     if (res.end) res.end();
   }
 
-  handleProxyError(code, kind, req, res) {
+  handleProxyError(code, kind, req, res, e) {
     // called when proxy itself has an error
     // so far, just 404 for no target and 503 for target not responding
     // custom error server gets `/CODE?url=/escapedUrl/`, e.g.
     // /404?url=%2Fuser%2Ffoo
 
     var proxy = this;
-    log.error("%s %s %s", code, req.method, req.url);
+    var errMsg = "";
     this.statsd.increment("requests." + code, 1);
+    if (e) {
+      // avoid stack traces on known not-our-problem errors:
+      // ECONNREFUSED (backend isn't there)
+      // ECONNRESET (backend is there, but didn't respond)
+      if (e.code === "ECONNRESET" || e.code === "ECONNREFUSED") {
+        errMsg = e.message;
+      } else {
+        // logging the error object shows a stack trace.
+        // Anything that gets here is an unknown error,
+        // so log more info.
+        errMsg = e;
+      }
+    }
+    log.error("%s %s %s", code, req.method, req.url, errMsg);
     if (!res) {
       // socket-level error, no response to build
       return;
@@ -482,8 +496,7 @@ class ConfigurableProxy extends EventEmitter {
 
       // add error handling
       args.push(function(e) {
-        log.error("Proxy error: ", e);
-        that.handleProxyError(503, kind, req, res);
+        that.handleProxyError(503, kind, req, res, e);
       });
 
       // update timestamp on any reply data as well (this includes websocket data)


### PR DESCRIPTION
These error codes occur for upstream issues, and aren't generally problems in the proxy.

- ECONNREFUSED means the target is not accepting connections (generally because it's not running)
- ECONNRESET means that a connection was made, but didn't receive a response before losing the connection
  (e.g. upstream shutdown before finishing, or didn't respond in a timely fashion)

We were logging stack traces for these messages, which users have reported as possible proxy problems, when they are generally not anything to be concerned about.

closes https://github.com/jupyterhub/jupyterhub/issues/1244