### PR TITLE
fix routing of URLs with query parameters exactly on the routing prefix

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -360,8 +360,9 @@ class ConfigurableProxy extends EventEmitter {
     var timer = this.statsd.createTimer("find_target_for_req");
     // return proxy target for a given url path
     var basePath = this.hostRouting ? "/" + parseHost(req) : "";
+    var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
 
-    return this._routes.getTarget(basePath + decodeURIComponent(req.url)).then(function(route) {
+    return this._routes.getTarget(path).then(function(route) {
       timer.stop();
       if (route) {
         return {

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -115,6 +115,23 @@ describe("Proxy Tests", function() {
       });
   });
 
+  it("/prefix?query is proxied correctly", function(done) {
+    util
+      .addTarget(proxy, "/bar", testPort, null, "/foo")
+      .then(() => r(proxyUrl + "/bar?query=foo"))
+      .then(body => {
+        body = JSON.parse(body);
+        expect(body).toEqual(
+          jasmine.objectContaining({
+            target: "http://127.0.0.1:" + testPort + "/foo",
+            path: "/bar",
+            url: "/foo/bar?query=foo",
+          })
+        );
+        done();
+      });
+  });
+
   it("handle URI encoding", function(done) {
     util
       .addTarget(proxy, "/b@r/b r", testPort, false, "/foo")


### PR DESCRIPTION
`/prefix?query` was routed incorrectly, while `/prefix/?query` would be handled fine