### PR TITLE
Add a pluggable strategy for storage

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -73,7 +73,8 @@ args
     "--proxy-timeout <n>",
     "Timeout (in millis) when proxy receives no response from target.",
     parseInt
-  );
+  )
+  .option("--storage-backend <storage-class>", "Define an external storage class. Defaults to in-MemoryStore.");
 
 args.parse(process.argv);
 
@@ -222,6 +223,9 @@ if (args.protocolRewrite) {
 if (!options.authToken) {
   log.warn("REST API is not authenticated.");
 }
+
+// external backend class
+options.storageBackend = args.storageBackend;
 
 var proxy = new ConfigurableProxy(options);
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -17,8 +17,7 @@ var http = require("http"),
   log = require("winston"),
   util = require("util"),
   URL = require("url"),
-  querystring = require("querystring"),
-  store = require("./store.js");
+  querystring = require("querystring");
 
 function bound(that, method) {
   // bind a method, to ensure `this=that` when it is called
@@ -129,13 +128,24 @@ function camelCaseify(options) {
   return camelOptions;
 }
 
+const loadStorage = (options) => {
+  if (options.storageBackend) {
+    const BackendStorageClass = require(options.storageBackend);
+    return new BackendStorageClass(options);
+  }
+
+  // loads default storage strategy
+  const store = require("./store.js");
+  return new store.MemoryStore(options);
+};
+
 class ConfigurableProxy extends EventEmitter {
   constructor(options) {
     super();
     var that = this;
     this.options = camelCaseify(options || {});
 
-    this._routes = new store.MemoryStore();
+    this._routes = loadStorage(options || {});
     this.authToken = this.options.authToken;
     if (options.includePrefix !== undefined) {
       this.includePrefix = options.includePrefix;

--- a/test/dummy-store.js
+++ b/test/dummy-store.js
@@ -1,0 +1,12 @@
+"use strict";
+
+class PlugableDummyStore {
+  get(path) {}
+  getTarget(path) {}
+  getAll() {}
+  add(path, data) {}
+  update(path, data) {}
+  remove(path) {}
+}
+
+module.exports = PlugableDummyStore;

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -210,6 +210,27 @@ describe("Proxy Tests", function() {
     });
   });
 
+  it("options.storageBackend", function(done) {
+    const options = {
+      storageBackend: "mybackend",
+    };
+    expect(() => {
+      const cp = new ConfigurableProxy(options);
+    }).toThrow(new Error("Cannot find module 'mybackend'"));
+    done();
+	});
+
+  it("options.storageBackend with an user-defined backend", function(done) {
+    const store = path.resolve(__dirname, 'dummy-store.js');
+    const options = {
+      storageBackend: store,
+    };
+    const cp = new ConfigurableProxy(options);
+    expect(cp._routes.constructor.name).toEqual("PlugableDummyStore");
+    done();
+  });
+
+
   it("includePrefix: false + prependPath: false", function(done) {
     proxy.includePrefix = false;
     proxy.proxy.options.prependPath = false;

--- a/test/store_spec.js
+++ b/test/store_spec.js
@@ -1,11 +1,11 @@
 // jshint jasmine: true
 "use strict";
 
-var store = require("../lib/store.js");
+var MemoryStore = require("../lib/store.js").MemoryStore;
 
 describe("MemoryStore", function() {
   beforeEach(function() {
-    this.subject = new store.MemoryStore();
+    this.subject = new MemoryStore();
   });
 
   describe("get", function() {


### PR DESCRIPTION
We'd like to suggest an alternative approach to solve https://github.com/jupyterhub/configurable-http-proxy/pull/85. This PR adds the ability to plug an external strategy for *configurable-http-proxy*. 

Currently, we have been working on an extension for redis: https://github.com/globocom/configurable-http-proxy-redis-backend 