### PR TITLE
Fix: avoid calling updateLastActivity for each chunk of data

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -510,14 +510,16 @@ class ConfigurableProxy extends EventEmitter {
         that.handleProxyError(503, kind, req, res, e);
       });
 
-      // update timestamp on any reply data as well (this includes websocket data)
-      req.on("data", function() {
-        that.updateLastActivity(prefix);
-      });
+      if (kind === "ws") {
+        // update timestamp on any reply data as well (this includes websocket data)
+        req.on("data", function() {
+          that.updateLastActivity(prefix);
+        });
 
-      res.on("data", function() {
-        that.updateLastActivity(prefix);
-      });
+        res.on("data", function() {
+          that.updateLastActivity(prefix);
+        });
+      }
 
       // update last activity timestamp in routing table
       return that.updateLastActivity(prefix).then(function() {


### PR DESCRIPTION
Instead of waiting for the complete data, `updateLastActivity` is being called for every chunk of data. It's a wrong behavior since we should expect for `end` request's event. Registering this `data` callback hangs the application.