### PR TITLE
register activity-monitoring after proxy setup

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -75,7 +75,10 @@ args
     "Timeout (in millis) when proxy receives no response from target.",
     parseInt
   )
-  .option("--storage-backend <storage-class>", "Define an external storage class. Defaults to in-MemoryStore.");
+  .option(
+    "--storage-backend <storage-class>",
+    "Define an external storage class. Defaults to in-MemoryStore."
+  );
 
 args.parse(process.argv);
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -128,7 +128,7 @@ function camelCaseify(options) {
   return camelOptions;
 }
 
-const loadStorage = (options) => {
+const loadStorage = options => {
   if (options.storageBackend) {
     const BackendStorageClass = require(options.storageBackend);
     return new BackendStorageClass(options);
@@ -510,7 +510,10 @@ class ConfigurableProxy extends EventEmitter {
         that.handleProxyError(503, kind, req, res, e);
       });
 
-      // update timestamp on any reply data as well (this includes websocket data)
+      // dispatch the actual method
+      that.proxy[kind].apply(that.proxy, args);
+
+      // update timestamp on any request/reply data as well (this includes websocket data)
       req.on("data", function() {
         that.updateLastActivity(prefix);
       });
@@ -520,10 +523,7 @@ class ConfigurableProxy extends EventEmitter {
       });
 
       // update last activity timestamp in routing table
-      return that.updateLastActivity(prefix).then(function() {
-        // dispatch the actual method
-        that.proxy[kind].apply(that.proxy, args);
-      });
+      return that.updateLastActivity(prefix);
     });
   }
 

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -218,10 +218,10 @@ describe("Proxy Tests", function() {
       const cp = new ConfigurableProxy(options);
     }).toThrow(new Error("Cannot find module 'mybackend'"));
     done();
-	});
+  });
 
   it("options.storageBackend with an user-defined backend", function(done) {
-    const store = path.resolve(__dirname, 'dummy-store.js');
+    const store = path.resolve(__dirname, "dummy-store.js");
     const options = {
       storageBackend: store,
     };
@@ -229,7 +229,6 @@ describe("Proxy Tests", function() {
     expect(cp._routes.constructor.name).toEqual("PlugableDummyStore");
     done();
   });
-
 
   it("includePrefix: false + prependPath: false", function(done) {
     proxy.includePrefix = false;


### PR DESCRIPTION
avoids prematurely consuming data when updateLastActivity takes a finite amount of time (db backend).

We need to make sure to hook up proxy consumer and activity monitor in the same tick, otherwise data could be lost to the activity tracker. This manifested only when using actually async storage backends (i.e. not the default).

closes #141