### PR TITLE
[wip] ensure optionally-decoded characters (@, ~) are treated the same as their encoded counterparts

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -370,7 +370,7 @@ class ConfigurableProxy extends EventEmitter {
     var timer = this.statsd.createTimer("find_target_for_req");
     // return proxy target for a given url path
     var basePath = this.hostRouting ? "/" + parseHost(req) : "";
-    var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
+    var path = basePath + URL.parse(req.url).pathname;
 
     return this._routes.getTarget(path).then(function(route) {
       timer.stop();

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -39,7 +39,10 @@ function stringToPath(s) {
     // special case because ''.split() gives [''], which is wrong.
     return [];
   } else {
-    return s.split("/");
+    // always decodeURIComponent to ensure that
+    // optionally-encoded symbols such as %40 and @
+    // are treated equally
+    return s.split("/").map(decodeURIComponent);
   }
 }
 

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -42,7 +42,13 @@ function stringToPath(s) {
     // always decodeURIComponent to ensure that
     // optionally-encoded symbols such as %40 and @
     // are treated equally
-    return s.split("/").map(decodeURIComponent);
+    return s.split("/").map(part => {
+      try {
+        return decodeURIComponent(part);
+      } catch (e) {
+        return part;
+      }
+    });
   }
 }
 

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -164,6 +164,22 @@ describe("Proxy Tests", function() {
       });
   });
 
+  // same as above, reversed
+  it("handle %40 in URI same as @", function(done) {
+    util
+      .addTarget(proxy, "/b%40r/b r", testPort, false, "/foo")
+      .then(() => r(proxyUrl + "/b@r/b%20r/rest/of/it"))
+      .then(body => {
+        body = JSON.parse(body);
+        expect(body).toEqual(
+          jasmine.objectContaining({
+            path: "/b%40r/b r",
+            url: "/foo/b@r/b%20r/rest/of/it",
+          })
+        );
+        done();
+      });
+  });
   it("prependPath: false prevents target path from being prepended", function(done) {
     proxy.proxy.options.prependPath = false;
     util

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -180,6 +180,24 @@ describe("Proxy Tests", function() {
         done();
       });
   });
+
+  // same as above, reversed
+  it("handle invalid url encoding", function(done) {
+    util
+      .addTarget(proxy, "/b%40r", testPort, false, "/foo")
+      .then(() => r(proxyUrl + "/b@r/b%/rest/of/it"))
+      .then(body => {
+        body = JSON.parse(body);
+        expect(body).toEqual(
+          jasmine.objectContaining({
+            path: "/b%40r",
+            url: "/foo/b@r/b%/rest/of/it",
+          })
+        );
+        done();
+      });
+  });
+
   it("prependPath: false prevents target path from being prepended", function(done) {
     proxy.proxy.options.prependPath = false;
     util


### PR DESCRIPTION
we already had it working one direction (%40->@), but not the other (@->%40)

related to jupyterhub/jupyterhub#1717 but not actually necessary for the fix