### PR TITLE
End to end ssl

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -166,7 +166,19 @@ if (args.apiSslKey || args.apiSslCert) {
     options.apiSsl.cert = fs.readFileSync(args.apiSslCert);
   }
   if (args.apiSslCa) {
-    options.apiSsl.ca = fs.readFileSync(args.apiSslCa);
+      // When multiple CAs need to be specified, they must be broken into
+      // an array of certs unfortunately.
+      var chain = fs.readFileSync(args.apiSslCa, 'utf8');
+      var ca = [];
+      var cert = [];
+      chain.split('\n').forEach(function(line) {
+        cert.push(line);
+        if (line.match(/-END CERTIFICATE-/)) {
+          ca.push(new Buffer(cert.join('\n')));
+          cert = [];
+        }
+      });
+      options.apiSsl.ca = ca;
   }
   if (args.sslDhparam) {
     options.apiSsl.dhparam = fs.readFileSync(args.sslDhparam);

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -166,19 +166,19 @@ if (args.apiSslKey || args.apiSslCert) {
     options.apiSsl.cert = fs.readFileSync(args.apiSslCert);
   }
   if (args.apiSslCa) {
-      // When multiple CAs need to be specified, they must be broken into
-      // an array of certs unfortunately.
-      var chain = fs.readFileSync(args.apiSslCa, 'utf8');
-      var ca = [];
-      var cert = [];
-      chain.split('\n').forEach(function(line) {
-        cert.push(line);
-        if (line.match(/-END CERTIFICATE-/)) {
-          ca.push(new Buffer(cert.join('\n')));
-          cert = [];
-        }
-      });
-      options.apiSsl.ca = ca;
+    // When multiple CAs need to be specified, they must be broken into
+    // an array of certs unfortunately.
+    var chain = fs.readFileSync(args.apiSslCa, 'utf8');
+    var ca = [];
+    var cert = [];
+    chain.split('\n').forEach(function(line) {
+      cert.push(line);
+      if (line.match(/-END CERTIFICATE-/)) {
+        ca.push(new Buffer(cert.join('\n')));
+        cert = [];
+      }
+    });
+    options.apiSsl.ca = ca;
   }
   if (args.sslDhparam) {
     options.apiSsl.dhparam = fs.readFileSync(args.sslDhparam);

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -248,22 +248,8 @@ class ConfigurableProxy extends EventEmitter {
 
     var that = this;
 
-    // Parse target into object to attach ssl params. The underlying
-    // http-proxy library will use this to attach ssl to the forwarded
-    // request.
-    data.target = URL.parse(data.target);
-    if(this.options.api_ssl){
-        data.target.key = this.options.api_ssl.key;
-        data.target.cert = this.options.api_ssl.cert;
-        data.target.ca = this.options.api_ssl.ca;
-    }
-
-    this._routes.add(path, data, function () {
-      that.update_last_activity(path, function () {
-        if (typeof(cb) === "function") {
-          cb();
-        }
-      });
+    return this._routes.add(path, data).then(() => {
+      this.updateLastActivity(path);
     });
   }
 
@@ -516,6 +502,13 @@ class ConfigurableProxy extends EventEmitter {
       if (!that.includePrefix) {
         req.url = req.url.slice(prefix.length);
       }
+      target = URL.parse(target);
+      if(that.options.apiSsl){
+          target.key = that.options.apiSsl.key;
+          target.cert = that.options.apiSsl.cert;
+          target.ca = that.options.apiSsl.ca;
+      }
+
 
       // add config argument
       args.push({ target: target });

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -450,8 +450,9 @@ class ConfigurableProxy extends EventEmitter {
       var urlSpec = URL.parse(this.errorTarget);
       urlSpec.search = "?" + querystring.encode({ url: req.url });
       urlSpec.pathname = urlSpec.pathname + code.toString();
+      var secure = /https/gi.test(urlSpec.protocol) ? true : false;
       var url = URL.format(urlSpec);
-      var errorRequest = http.request(url, function(upstream) {
+      var errorRequest = (secure ? https : http).request(url, function(upstream) {
         ["content-type", "content-encoding"].map(function(key) {
           if (!upstream.headers[key]) return;
           if (res.setHeader) res.setHeader(key, upstream.headers[key]);

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -248,8 +248,22 @@ class ConfigurableProxy extends EventEmitter {
 
     var that = this;
 
-    return this._routes.add(path, data).then(() => {
-      this.updateLastActivity(path);
+    // Parse target into object to attach ssl params. The underlying
+    // http-proxy library will use this to attach ssl to the forwarded
+    // request.
+    data.target = URL.parse(data.target);
+    if(this.options.forwardSsl){
+        data.target.key = this.options.api_ssl.key;
+        data.target.cert = this.options.api_ssl.cert;
+        data.target.ca = this.options.api_ssl.ca;
+    }
+
+    this._routes.add(path, data, function () {
+      that.update_last_activity(path, function () {
+        if (typeof(cb) === "function") {
+          cb();
+        }
+      });
     });
   }
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -252,7 +252,7 @@ class ConfigurableProxy extends EventEmitter {
     // http-proxy library will use this to attach ssl to the forwarded
     // request.
     data.target = URL.parse(data.target);
-    if(this.options.forwardSsl){
+    if(this.options.api_ssl){
         data.target.key = this.options.api_ssl.key;
         data.target.cert = this.options.api_ssl.cert;
         data.target.ca = this.options.api_ssl.ca;


### PR DESCRIPTION
These changes are in service of turning on SSL internally for JupyterHub in reference to [JupyterHub issue 371](https://github.com/jupyterhub/jupyterhub/issues/370).

The change amounts to creating a URL object from a stored target url string. This allows for attaching certs to a request to a target.