### PR TITLE
allow specifying passphrases for ssl key(s) via environment variables

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -137,6 +137,9 @@ if (args.sslKey || args.sslCert) {
   options.ssl = {};
   if (args.sslKey) {
     options.ssl.key = fs.readFileSync(args.sslKey);
+    if (process.env.CONFIGPROXY_SSL_KEY_PASSPHRASE) {
+      options.ssl.passphrase = process.env.CONFIGPROXY_SSL_KEY_PASSPHRASE;
+    }
   }
   if (args.sslCert) {
     options.ssl.cert = fs.readFileSync(args.sslCert);
@@ -161,6 +164,9 @@ if (args.apiSslKey || args.apiSslCert) {
   options.apiSsl = {};
   if (args.apiSslKey) {
     options.apiSsl.key = fs.readFileSync(args.apiSslKey);
+    if (process.env.CONFIGPROXY_API_SSL_KEY_PASSPHRASE) {
+      options.apiSsl.passphrase = process.env.CONFIGPROXY_API_SSL_KEY_PASSPHRASE;
+    }
   }
   if (args.apiSslCert) {
     options.apiSsl.cert = fs.readFileSync(args.apiSslCert);


### PR DESCRIPTION
set CONFIGPROXY_SSL_KEY_PASSPHRASE env to specify the passphrase for the ssl key. (API_SSL_KEY... for the API endpoint).

closes https://github.com/jupyterhub/jupyterhub/issues/1134