### PR TITLE
Add debugging utilities to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:6-alpine
+FROM node:10-alpine
 
 EXPOSE 8000
+
+# Useful tools for debugging
+RUN apk add --no-cache jq curl
 
 ADD . /srv/configurable-http-proxy
 WORKDIR /srv/configurable-http-proxy


### PR DESCRIPTION
`curl` and `jq` are very useful when you wanna look at 
the routing table manually when debugging inside the container.
They also don't make the image too much bigger.

Also bump node version to latest LTS.