### PR TITLE
Update the instruction for required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ functionality to [JupyterHub] deployments.
 
 ## Install
 
-Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 4
+Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 6
 
-*Note: Ubuntu < 16.04 and Debian Jessie ship with outdated versions of Node
-and must be upgraded. We recommend using the latest stable or LTS version
-of Node.*
+If you're installing `configurable-http-proxy` in Linux, you can follow [the instruction of nodesource](https://github.com/nodesource/distributions#installation-instructions) to install arbitrary version of Node.js.
 
 To install the `configurable-http-proxy` package globally
 using npm:


### PR DESCRIPTION
This package requires Node.js v6 [instead of v4 now](https://github.com/jupyterhub/configurable-http-proxy/commit/f824c65d9bf7d8a4d050b9fbfd8db65dcde65f6d)

I updated the README so people don't get confused and spend quite a few time to debug syntax errors such as destructuring.