### PR TITLE
corrected request body for Add proxy request

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,7 @@ dictionary with at least one key: `target`, the target host to be proxied.
 Example request body:
 ```json
 {
-  "/user/fred": {
-    "target": "http://localhost:8002"
-  },
-  "/user/barbara": {
-    "target": "http://localhost:8003"
-  }
+  "target": "http://localhost:8002"
 }
 ```
 


### PR DESCRIPTION
This Pr contains correction in the README file.

The request body for create proxy endpoint POST /api/route/[:path] is corrected.