### PR TITLE
Uncaught Exception logs e.message and e.stack

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -373,5 +373,8 @@ process.on("SIGINT", function() {
 
 // log uncaught exceptions, don't exit now that setup is complete
 process.on("uncaughtException", function(e) {
-  log.error("Uncaught Exception", e.stack);
+  log.error("Uncaught Exception:" + e.message);
+  if (e.stack) {
+    log.error(e.stack);
+  }
 });

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -373,7 +373,7 @@ process.on("SIGINT", function() {
 
 // log uncaught exceptions, don't exit now that setup is complete
 process.on("uncaughtException", function(e) {
-  log.error("Uncaught Exception:" + e.message);
+  log.error("Uncaught Exception: " + e.message);
   if (e.stack) {
     log.error(e.stack);
   }


### PR DESCRIPTION
The log.error call was incorrect, and this includes the message with a check for a stack (non-standard, but well supported).