### PR TITLE
Command line option for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Options:
   --auto-rewrite                     Rewrite the Location header host/port in redirect responses
   --change-origin                    Changes the origin of the host header to the target URL
   --protocol-rewrite <proto>         Rewrite the Location header protocol in redirect responses to the specified protocol
+  --custom-headers <headers>         Comma separated list of custom headers to add to proxied requests (k1:v1,k2:v2,...)
   --insecure                         Disable SSL cert verification
   --host-routing                     Use host routing (host as first level of path)
 

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -82,8 +82,9 @@ args
     "Rewrite the Location header protocol in redirect responses to the specified protocol"
   )
   .option(
-    "--custom-headers <headers>",
-    "Comma separated list of custom headers to add to proxied requests (k1:v1,k2:v2,...)"
+    "--custom-header <header>",
+    "Custom header to add to proxied requests. Use same option for multiple headers (--custom-header k1:v1 --custom-header k2:v2)",
+    collect, []
   )
   .option("--insecure", "Disable SSL cert verification")
   .option("--host-routing", "Use host routing (host as first level of path)")
@@ -100,6 +101,10 @@ args
     "--storage-backend <storage-class>",
     "Define an external storage class. Defaults to in-MemoryStore."
   );
+
+function collect(value, previous) {
+  return previous.concat([value]);
+}
 
 args.parse(process.argv);
 
@@ -299,14 +304,14 @@ if (!options.authToken) {
 }
 
 // custom headers option
-options.customHeaders = [];
-if (args.customHeaders) {
-  options.customHeaders = args.customHeaders.toString().split(',').map(s => s.trim()).map(header => {
+options.customHeader = [];
+if (args.customHeader) {
+  options.customHeader = args.customHeader.map(s => s.trim()).map(header => {
     var i = header.indexOf(':');
     var key, value;
     if (i < 0) {
-      key = header;
-      value = '';
+      log.error("Custom header is invalid: " + header);
+      process.exit(1);
     }
     else {
       var key = header.substr(0, i).trim();

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -81,6 +81,10 @@ args
     "--protocol-rewrite <proto>",
     "Rewrite the Location header protocol in redirect responses to the specified protocol"
   )
+  .option(
+    "--custom-headers <headers>",
+    "Comma separated list of custom headers to add to proxied requests (k1:v1,k2:v2,...)"
+  )
   .option("--insecure", "Disable SSL cert verification")
   .option("--host-routing", "Use host routing (host as first level of path)")
   .option("--statsd-host <host>", "Host to send statsd statistics to")
@@ -292,6 +296,24 @@ if (args.protocolRewrite) {
 
 if (!options.authToken) {
   log.warn("REST API is not authenticated.");
+}
+
+// custom headers option
+options.customHeaders = [];
+if (args.customHeaders) {
+  options.customHeaders = args.customHeaders.toString().split(',').map(s => s.trim()).map(header => {
+    var i = header.indexOf(':');
+    var key, value;
+    if (i < 0) {
+      key = header;
+      value = '';
+    }
+    else {
+      var key = header.substr(0, i).trim();
+      var value = header.substr(i + 1).trim();
+    }
+    return { 'key': key, 'value': value };
+  }).filter(header => header.key);
 }
 
 // external backend class

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -229,9 +229,9 @@ class ConfigurableProxy extends EventEmitter {
 
     this.proxy.on("proxyRes", function(proxyRes, req, res) {
       that.statsd.increment("requests." + proxyRes.statusCode, 1);
-      that.customHeaders.forEach(function (header) {
-        res.setHeader(header.key, header.value);
-      });
+      if (that.customHeaders) {
+        that.customHeaders.forEach(header => res.setHeader(header.key, header.value));
+      }
     });
   }
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -145,6 +145,7 @@ class ConfigurableProxy extends EventEmitter {
     } else {
       this.includePrefix = true;
     }
+    this.customHeaders = this.options.customHeaders;
     this.hostRouting = this.options.hostRouting;
     this.errorTarget = options.errorTarget;
     if (this.errorTarget && this.errorTarget.slice(-1) !== "/") {
@@ -228,6 +229,9 @@ class ConfigurableProxy extends EventEmitter {
 
     this.proxy.on("proxyRes", function(proxyRes, req, res) {
       that.statsd.increment("requests." + proxyRes.statusCode, 1);
+      that.customHeaders.forEach(function (header) {
+        res.setHeader(header.key, header.value);
+      });
     });
   }
 


### PR DESCRIPTION
Resolves #205.

> `configurable-http-proxy` supports a wide range of configuration options, but it is not practical for it to cover all use cases. An example of an uncovered use case is the [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)  response header. Instead of adding yet another configuration option specifically for this header I propose we implement a `--custom-headers <headers>` configuration option that allows for user-specified headers to be added to all proxied requests. Upstream projects like https://github.com/jupyterhub/zero-to-jupyterhub-k8s can expose the option to be passed to `configurable-http-proxy`, for example through the Helm chart.