### PR TITLE
Change user to numeric value for k8s compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ ADD . /srv/configurable-http-proxy
 WORKDIR /srv/configurable-http-proxy
 RUN npm install -g
 
-USER nobody
+USER 65534
 
 ENTRYPOINT ["/srv/configurable-http-proxy/chp-docker-entrypoint"]


### PR DESCRIPTION
When a k8s cluster enforces the PodSecurityPolicy "MustRunAsNonRoot" it requires a numeric user to verify, as per documentation https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups.

I therefore simply changed the `USER` to the numeric equivalent of `nobody`.