### PR TITLE
Terminate on SIGTERM

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -364,10 +364,17 @@ if (options.redirectPort && listen.port !== 80) {
     });
 }
 
-// trigger normal exit on sigint
+// trigger normal exit on SIGINT
 // without this, PID cleanup won't fire on SIGINT
 process.on("SIGINT", function() {
   log.warn("Interrupted");
+  process.exit(2);
+});
+
+// trigger normal exit on SIGTERM
+// fired on `docker stop` and during Kubernetes pod container evictions
+process.on("SIGTERM", function() {
+  log.warn("Terminated");
   process.exit(2);
 });
 


### PR DESCRIPTION
Closes #215 by listening for a SIGTERM signal.

This has been tested to make a difference by issuing a `docker stop` command as described in #215. It now shuts down very quickly while before it took the full timeout duration for it to shutdown, which I interpret as it required a SIGKILL signal to be sent for it to react at all.

I wrote out an exit code of 2 like for SIGINT, I'm not sure what makes sense here or if it will matter anywhere.

Having this merged and released could impact Z2JH / BinderHub performance during upgrades and when draining nodes etc, making a BinderHub not go inresponsive for 30 seconds I believe.
