### PR TITLE
RELEASE.md documentation and small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   except:
     - /^greenkeeper.*/
 node_js:
+  - 12
   - 10
   - 8
   - 6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:12.13-alpine
+# ref: https://hub.docker.com/_/node?tab=tags&name=12
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
@@ -10,6 +11,12 @@ COPY . /srv/configurable-http-proxy
 WORKDIR /srv/configurable-http-proxy
 RUN npm install -g
 
+# Switch from the root user to the nobody user
 USER 65534
+
+# Expose the proxy for traffic to be proxied (8000) and the
+# REST API where it can be configured (8001)
+EXPOSE 8000
+EXPOSE 8001
 
 ENTRYPOINT ["/srv/configurable-http-proxy/chp-docker-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# configurable-http-proxy
+# [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
 
 [![Build Status](https://travis-ci.org/jupyterhub/configurable-http-proxy.svg?branch=master)](https://travis-ci.org/jupyterhub/configurable-http-proxy)
+![Docker Pulls](https://img.shields.io/docker/pulls/jupyterhub/configurable-http-proxy)
 [![npm](https://img.shields.io/npm/v/configurable-http-proxy.svg)](https://www.npmjs.com/package/configurable-http-proxy)
 
 **configurable-http-proxy** (CHP) provides you with a way to update and manage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
 
-[![Build Status](https://travis-ci.org/jupyterhub/configurable-http-proxy.svg?branch=master)](https://travis-ci.org/jupyterhub/configurable-http-proxy)
-[![Docker Automated build](https://img.shields.io/docker/automated/jupyterhub/configurable-http-proxy)](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
-[![npm](https://img.shields.io/npm/v/configurable-http-proxy.svg)](https://www.npmjs.com/package/configurable-http-proxy)
+[![TravisCI Build status](https://img.shields.io/travis/jupyterhub/configurable-http-proxy/master.svg?logo=travis)](https://travis-ci.org/jupyterhub/configurable-http-proxy)
+[![Docker Build status](https://img.shields.io/docker/build/jupyterhub/configurable-http-proxy?logo=docker&label=build)](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
+[![npm](https://img.shields.io/npm/v/configurable-http-proxy.svg?logo=npm)](https://www.npmjs.com/package/configurable-http-proxy)
 
 **configurable-http-proxy** (CHP) provides you with a way to update and manage
 a proxy table using a command line interface or REST API.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
 
 [![Build Status](https://travis-ci.org/jupyterhub/configurable-http-proxy.svg?branch=master)](https://travis-ci.org/jupyterhub/configurable-http-proxy)
-![Docker Pulls](https://img.shields.io/docker/pulls/jupyterhub/configurable-http-proxy)
+[![Docker Automated build](https://img.shields.io/docker/automated/jupyterhub/configurable-http-proxy)](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
 [![npm](https://img.shields.io/npm/v/configurable-http-proxy.svg)](https://www.npmjs.com/package/configurable-http-proxy)
 
 **configurable-http-proxy** (CHP) provides you with a way to update and manage

--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ configurable-http-proxy --default-target=http://localhost:8888
 Usage: configurable-http-proxy [options]
 
 Options:
-
   -V, --version                      output the version number
   --ip <ip-address>                  Public-facing IP of the proxy
   --port <n> (defaults to 8000)      Public-facing port of the proxy
-
   --ssl-key <keyfile>                SSL key to use, if any
   --ssl-cert <certfile>              SSL certificate to use, if any
   --ssl-ca <ca-file>                 SSL certificate authority, if any
@@ -117,7 +115,6 @@ Options:
   --ssl-ciphers <ciphers>            `:`-separated ssl cipher list. Default excludes RC4
   --ssl-allow-rc4                    Allow RC4 cipher for SSL (disabled by default)
   --ssl-dhparam <dhparam-file>       SSL Diffie-Helman Parameters pem file, if any
-
   --api-ip <ip>                      Inward-facing IP for API requests (default: "localhost")
   --api-port <n>                     Inward-facing port for API requests (defaults to --port=value+1)
   --api-ssl-key <keyfile>            SSL key to use, if any, for API requests
@@ -125,13 +122,11 @@ Options:
   --api-ssl-ca <ca-file>             SSL certificate authority, if any, for API requests
   --api-ssl-request-cert             Request SSL certs to authenticate clients for API requests
   --api-ssl-reject-unauthorized      Reject unauthorized SSL connections (only meaningful if --api-ssl-request-cert is given)
-
   --client-ssl-key <keyfile>         SSL key to use, if any, for proxy to client requests
   --client-ssl-cert <certfile>       SSL certificate to use, if any, for proxy to client requests
   --client-ssl-ca <ca-file>          SSL certificate authority, if any, for proxy to client requests
   --client-ssl-request-cert          Request SSL certs to authenticate clients for API requests
   --client-ssl-reject-unauthorized   Reject unauthorized SSL connections (only meaningful if --client-ssl-request-cert is given)
-
   --default-target <host>            Default proxy target (proto://host[:port])
   --error-target <host>              Alternate server for handling proxy errors (proto://host[:port])
   --error-path <path>                Alternate server for handling proxy errors (proto://host[:port])
@@ -144,14 +139,15 @@ Options:
   --auto-rewrite                     Rewrite the Location header host/port in redirect responses
   --change-origin                    Changes the origin of the host header to the target URL
   --protocol-rewrite <proto>         Rewrite the Location header protocol in redirect responses to the specified protocol
-  --custom-headers <headers>         Comma separated list of custom headers to add to proxied requests (k1:v1,k2:v2,...)
+  --custom-header <header>           Custom header to add to proxied requests. Use same option for multiple headers (--custom-header k1:v1 --custom-header k2:v2)
+                                     (default: [])
   --insecure                         Disable SSL cert verification
   --host-routing                     Use host routing (host as first level of path)
-
   --statsd-host <host>               Host to send statsd statistics to
   --statsd-port <port>               Port to send statsd statistics to
   --statsd-prefix <prefix>           Prefix to use for statsd statistics
   --log-level <loglevel>             Log level (debug, info, warn, error) (default: "info")
+  --timeout <n>                      Timeout (in millis) when proxy drops connection for a request.
   --proxy-timeout <n>                Timeout (in millis) when proxy receives no response from target.
   --storage-backend <storage-class>  Define an external storage class. Defaults to in-MemoryStore.
   -h, --help                         output usage information

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,66 @@
+# How to make a release
+
+`configurable-http-proxy` is available as a _npm package_ [available on
+npmjs](https://www.npmjs.com/package/configurable-http-proxy) and a _Docker
+image_ available on
+[DockerHub](https://hub.docker.com/r/jupyterhub/configurable-http-proxy). The
+Docker image is automatically built and published on changes to the git
+repository as is configured
+[here](https://hub.docker.com/repository/docker/jupyterhub/configurable-http-proxy/builds).
+
+To make a tagged release follow the instructions below, but first make sure you
+meet the prerequisites:
+- To be a collaborator of the [npmjs
+  project](https://www.npmjs.com/package/configurable-http-proxy).
+- To have push rights to the [configurable-http-proxy GitHub
+  repository](https://github.com/jupyterhub/configurable-http-proxy).
+- To have [`bump2version`](https://github.com/c4urself/bump2version) installed
+  (`pip install bump2version`).
+
+## Steps to make a release
+
+1. Update [CHANGELOG.md](CHANGELOG.md) if it is not up to date, and verify
+   [README.md](README.md) has an updated output of running `--help`. Make a PR
+   to review the CHANGELOG notes.
+
+1. Once the changelog is up to date, checkout master and make sure it is up to
+   date and clean.
+
+   ```bash
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Update the version with `bump2version` to not include the -dev suffix and let
+   it make a git commit and tag as well for us.
+
+   ```bash
+   # optionally first bump a minor or major version, but
+   # don't bump the patch version, that's already done.
+   # bump2version --no-commit minor
+   # bump2version --no-commit major
+   bump2version --tag release
+   ```
+
+1. Publish to NPM.
+
+   ```bash
+   npm publish
+   ```
+
+1. Reset the version to the next development version with `bump2version`.
+
+   ```bash
+   bump2version --no-tag patch
+   ```
+
+1. Push your release related commits to master along with the annotated tags
+   referencing commits on the master branch.
+
+   ```
+   git push --follow-tags $ORIGIN master
+   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1090,19 +1090,35 @@
       }
     },
     "jasmine": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
-      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
+      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.6",
-        "jasmine-core": "~3.1.0"
+        "glob": "^7.1.4",
+        "jasmine-core": "~3.5.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "jasmine-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
-      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
+      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "winston": "~3.2.0"
   },
   "devDependencies": {
-    "jasmine": "^3.0.0",
+    "jasmine": "^3.5.0",
     "jshint": "^2.10.2",
     "nyc": "^14.0.0",
     "prettier": "^1.4.4",

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -216,7 +216,9 @@ describe("Proxy Tests", function() {
     };
     expect(() => {
       const cp = new ConfigurableProxy(options);
-    }).toThrow(new Error("Cannot find module 'mybackend'"));
+    }).toThrowMatching(function(e) {
+      return e.message.includes("Cannot find module 'mybackend'");
+    });
     done();
   });
 


### PR DESCRIPTION
## PR Summary
- Added a dockerhub badge to the readme
- Started testing Node version 12 in travis
- Exposed port 8000 and 8001 in the Dockerfile, which doesn't mean you automatically have them exposed if you run `docker run` but indicates two ports in use by the software within the Dockerfile that could very well want to be _published_ by the `-P` flag or `-p 8000:8000` flag for example.
- Added my best attempted documentation on how to make a release in a RELEASE.md file. This comes to a large extent from a Chartpress PR (https://github.com/jupyterhub/chartpress/pull/74) by @minrk. I adopted bump2version as I saw a .bumpversion.cfg file in this repo.
  - Changelog
  - Version bumping and git commit tagging
  - Pushing to NPM
  - Resetting the version to `-dev`

## Help requested (RESOLVED)
I note that the [build is failing on Node 12](https://travis-ci.org/jupyterhub/configurable-http-proxy/jobs/611011264?utm_medium=notification&utm_source=github_status), yet I know that we bumped the [Dockerfile](https://github.com/jupyterhub/configurable-http-proxy/blob/master/Dockerfile) to start with a `FROM node:12.13-alpine` statement recently in #213. Solving this is very relevant I figure.

**UPDATE:** I fixed this issue in 7238f2b by relaxing the test a bit... It may be caused by an upstream bug in node or jasmine but I'm not in ready to search and fix that at the moment. The test failure said that it expected "asdf" but got "asdf" more or less, which is very weird to me. I assumed there could be some type difference etc so I started looking for if the error message contained the relevant string instead of explicitly testing for a matching error object.

## Review suggestions (RESOLVED)
I stopped testing of node 6 on a gut feeling when adding node 12, should I keep support for node 6 perhaps? Should we drop testing of node 6 and also adjust package.json's constraint on the node version to be node >= 8?

**RESOLVED:** We continue to test and allow for node 6 to be used.