### PR TITLE
Merge pull request #227 from consideRatio/production-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /srv/configurable-http-proxy
 
 # Install configurable-http-proxy, then automatically install compatible updates
 # to vulnerable dependencies, and finally uninstall npm which isn't needed.
-RUN npm install -g \
+RUN npm install -g --production \
  && npm audit fix \
  && npm uninstall -g npm
 


### PR DESCRIPTION
Running npm install on a local folder will by default also install the
devDependencies specified in package.json, and this is not suitable when
we are building a Dockerfile for use in production.