### PR TITLE
move `npm audit` to CI from Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - npm install -g codecov
   - npm install
 script:
+  - npm audit # if npm audit fails, run `npm audit fix` and commit the results
   - npm run lint
   - travis_retry npm test
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-alpine
+FROM node:12-alpine
 # ref: https://hub.docker.com/_/node?tab=tags&name=12
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
@@ -10,11 +10,8 @@ RUN mkdir -p /srv/configurable-http-proxy
 COPY . /srv/configurable-http-proxy
 WORKDIR /srv/configurable-http-proxy
 
-# Install configurable-http-proxy, then automatically install compatible updates
-# to vulnerable dependencies, and finally uninstall npm which isn't needed.
-RUN npm install -g --production \
- && npm audit fix \
- && npm uninstall -g npm
+# Install configurable-http-proxy
+RUN npm install -g --production
 
 # Switch from the root user to the nobody user
 USER 65534


### PR DESCRIPTION
If this new test stage fails, running `npm audit fix` and committing the result will fix it.

Moves the fixes to the repo's package-lock.json, rather than deferring to the docker build. This means that all installs of CHP will get fixes, not just docker, and ensures that package-lock.json accurately represents what is installed in the image.

It also ensures that we are notified when a fix is needed.

The base image is also pinned only to the major node version to ensure that security patches are received on every build, rather than forcing us to keep bumping the base image.

This also reverts the removal of npm in #226, which didn't have any effect on the vulnerability of the image, but there may be some unfortunate policy reasons why it needs to be done, despite having no effect.