### PR TITLE
CI: test against node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
-sudo: false
 branches:
   except:
     - /^greenkeeper.*/
 # Test against Long Term Support (LTS) releases in a "current", "active", and
 # "maintenance" status: https://nodejs.org/en/about/releases/
 node_js:
+  - 14
   - 12
   - 10
 install:


### PR DESCRIPTION
Added tests against node14 which is available since April, following the recommendations in a comment of .travis.yml to test [LTS releases](https://nodejs.org/en/about/releases/) marked as current/active/maintenance.
- Removal of `sudo: false` is because it does nothing and is deprecated in TravisCI.