### PR TITLE
CI: npm-audit cronjob in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: node_js
 branches:
   except:
     - /^greenkeeper.*/
+
+stages:
+  - name: test
+    if: type IN (push, pull_request, api)
+  - name: cron
+    if: type IN (cron, api)
+
 # Test against Long Term Support (LTS) releases in a "current", "active", and
 # "maintenance" status: https://nodejs.org/en/about/releases/
 node_js:
@@ -9,10 +16,23 @@ node_js:
   - 12
   - 10
 install:
-  - npm install -g codecov
-  - npm install
+  - npm ci  # install from package-lock.json
 script:
   - npm run lint
   - travis_retry npm test
 after_success:
+  - npm install -g codecov
   - npm run codecov
+
+include:
+  jobs:
+    - name: deps:npm-audit
+      stage: cron
+      install:
+        - npm ci --production
+      script:
+        - npm audit
+      after_success:
+        - echo "package-lock.json is considered secure according to 'npm audit'."
+      after_failure:
+        - echo "package-lock.json should be updated with 'npm audit fix'."


### PR DESCRIPTION
A PR relating to @minrk's #228.

We add a TravisCI job definition, that will only run on TravisCI configured CronJobs, and then we configure this to run daily, and we get informed about the need to do run `npm audit fix`.