### PR TITLE
CI: fix .travis.yml syntax for cronjob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# .travis.yml development advice: check your changes at
+# https://config.travis-ci.com/explore
+os: linux
+dist: bionic
 language: node_js
 branches:
   except:
@@ -24,8 +28,8 @@ after_success:
   - npm install -g codecov
   - npm run codecov
 
-include:
-  jobs:
+jobs:
+  include:
     - name: deps:npm-audit
       stage: cron
       install:


### PR DESCRIPTION
I messed up the syntax in #239, so in this PR i fix it, and also become explicit about the OS and Dist for the VM we run the CI jobs on, which switch from ubuntu xenial 16.04 -> ubuntu bionic 18.04.