### PR TITLE
Docker image: use package-lock.json and only include relevant parts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore everything...
+*
+# ... except:
+!bin/
+!lib/
+!chp-docker-entrypoint
+!index.js
+!package*.json
+!LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache jq curl
 RUN mkdir -p /srv/configurable-http-proxy
 COPY . /srv/configurable-http-proxy/
 WORKDIR /srv/configurable-http-proxy
+ENV PATH=/srv/configurable-http-proxy/bin:$PATH
 
 # Install configurable-http-proxy according to package-lock.json (ci) without
 # devDepdendencies (--production), then uninstall npm which isn't needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 # Useful tools for debugging
 RUN apk add --no-cache jq curl
 
+# Copy relevant (see .dockerignore)
 RUN mkdir -p /srv/configurable-http-proxy
 COPY . /srv/configurable-http-proxy/
 WORKDIR /srv/configurable-http-proxy
-ENV PATH=/srv/configurable-http-proxy/bin:$PATH
 
 # Install configurable-http-proxy according to package-lock.json (ci) without
 # devDepdendencies (--production), then uninstall npm which isn't needed.
@@ -24,4 +24,6 @@ USER 65534
 EXPOSE 8000
 EXPOSE 8001
 
+# Put configurable-http-proxy on path for chp-docker-entrypoint
+ENV PATH=/srv/configurable-http-proxy/bin:$PATH
 ENTRYPOINT ["/srv/configurable-http-proxy/chp-docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,12 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 RUN apk add --no-cache jq curl
 
 RUN mkdir -p /srv/configurable-http-proxy
-COPY . /srv/configurable-http-proxy
+COPY . /srv/configurable-http-proxy/
 WORKDIR /srv/configurable-http-proxy
 
-# Install configurable-http-proxy, then automatically install compatible updates
-# to vulnerable dependencies, and finally uninstall npm which isn't needed.
-RUN npm install -g --production \
- && npm audit fix \
+# Install configurable-http-proxy according to package-lock.json (ci) without
+# devDepdendencies (--production), then uninstall npm which isn't needed.
+RUN npm ci --production \
  && npm uninstall -g npm
 
 # Switch from the root user to the nobody user

--- a/chp-docker-entrypoint
+++ b/chp-docker-entrypoint
@@ -41,4 +41,4 @@ case "$@" in
     ARGS="--api-ip=0.0.0.0";;
 esac
 
-exec bin/configurable-http-proxy $ARGS "$@"
+exec configurable-http-proxy $ARGS "$@"

--- a/chp-docker-entrypoint
+++ b/chp-docker-entrypoint
@@ -41,4 +41,4 @@ case "$@" in
     ARGS="--api-ip=0.0.0.0";;
 esac
 
-exec configurable-http-proxy $ARGS "$@"
+exec bin/configurable-http-proxy $ARGS "$@"


### PR DESCRIPTION
Together with the TravisCI Job definition added in #239 / #240 and [configured to run in TravisCI settings](https://travis-ci.org/github/jupyterhub/configurable-http-proxy/settings), I suggest this PR replace #228.

Closes #228.