### PR TITLE
fix: --custom-header flag implementation

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -84,7 +84,7 @@ args
   .option(
     "--custom-header <header>",
     "Custom header to add to proxied requests. Use same option for multiple headers (--custom-header k1:v1 --custom-header k2:v2)",
-    collect, []
+    collectHeadersIntoObject, {}
   )
   .option("--insecure", "Disable SSL cert verification")
   .option("--host-routing", "Use host routing (host as first level of path)")
@@ -107,8 +107,15 @@ args
     "Define an external storage class. Defaults to in-MemoryStore."
   );
 
-function collect(value, previous) {
-  return previous.concat([value]);
+// collects multiple flags to an object
+// --custom-header "k1:v1" --custom-header " k2 : v2 " --> {"k1":"v1","k2":"v2"}
+function collectHeadersIntoObject(value, previous) {
+  var headerParts = value.split(":").map(p => p.trim())
+  if (headerParts.length != 2) {
+    log.error("A single colon was expected in custom header: " + value);
+    process.exit(1);
+  }
+  previous[headerParts[0]] = headerParts[1]
 }
 
 args.parse(process.argv);
@@ -263,6 +270,7 @@ options.hostRouting = args.hostRouting;
 options.authToken = process.env.CONFIGPROXY_AUTH_TOKEN;
 options.redirectPort = args.redirectPort;
 options.redirectTo = args.redirectTo;
+options.headers = args.customHeader;
 options.timeout = args.timeout;
 options.proxyTimeout = args.proxyTimeout;
 
@@ -307,24 +315,6 @@ if (args.protocolRewrite) {
 
 if (!options.authToken) {
   log.warn("REST API is not authenticated.");
-}
-
-// custom headers option
-options.customHeader = [];
-if (args.customHeader) {
-  options.customHeader = args.customHeader.map(s => s.trim()).map(header => {
-    var i = header.indexOf(':');
-    var key, value;
-    if (i < 0) {
-      log.error("Custom header is invalid: " + header);
-      process.exit(1);
-    }
-    else {
-      var key = header.substr(0, i).trim();
-      var value = header.substr(i + 1).trim();
-    }
-    return { 'key': key, 'value': value };
-  }).filter(header => header.key);
 }
 
 // external backend class

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -145,7 +145,7 @@ class ConfigurableProxy extends EventEmitter {
     } else {
       this.includePrefix = true;
     }
-    this.customHeaders = this.options.customHeaders;
+    this.headers = this.options.headers;
     this.hostRouting = this.options.hostRouting;
     this.errorTarget = options.errorTarget;
     if (this.errorTarget && this.errorTarget.slice(-1) !== "/") {
@@ -229,9 +229,6 @@ class ConfigurableProxy extends EventEmitter {
 
     this.proxy.on("proxyRes", function(proxyRes, req, res) {
       that.statsd.increment("requests." + proxyRes.statusCode, 1);
-      if (that.customHeaders) {
-        that.customHeaders.forEach(header => res.setHeader(header.key, header.value));
-      }
     });
   }
 

--- a/test/cli_spec.js
+++ b/test/cli_spec.js
@@ -193,4 +193,29 @@ describe("CLI Tests", function() {
         });
     });
   });
+
+  it("custom-header", function(done) {
+    var args = [
+        '--ip', '127.0.0.1',
+        '--ssl-cert', 'test/server.crt',
+        '--ssl-key', 'test/server.key',
+        '--port', port,
+        '--default-target', testUrl,
+        '--custom-header', 'k1: v1',
+        '--custom-header', ' k2 : v2 v2 ',
+    ];
+    executeCLI(execCmd, args).then((cliProcess) => {
+        childProcess = cliProcess;
+        r(SSLproxyUrl).then(body => {
+            body = JSON.parse(body);
+            expect(body.headers).toEqual(
+              jasmine.objectContaining({
+                k1: "v1",
+                k2: "v2 v2",
+              })
+            );
+            done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
The `--custom-header` flag added in #206 didn't seem to work, this PR attempts to fix this and also adds a test to make sure.

**Given current node-http-server, the key fixes are:**
- A singular/plural typo for `customHeader(s)`
- node-http-proxy configuration API, it now needs to be [`headers` and not `customHeaders`](https://github.com/http-party/node-http-proxy#options)
- `headers` now needs to get an object, not a list of objects

Closes #223.