### PR TITLE
Emit proxyRequestWs events correctly, and some inline docs

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -510,7 +510,12 @@ class ConfigurableProxy extends EventEmitter {
         return;
       }
 
-      that.emit("proxyRequest", req, res);
+      if (kind === "web") {
+        that.emit("proxyRequest", req, res);
+      }
+      else {
+        that.emit("proxyRequestWs", req, res, args[2]);
+      }
       var prefix = match.prefix;
       var target = match.target;
       that.log.debug("PROXY %s %s to %s", kind.toUpperCase(), req.url, target);

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -496,6 +496,11 @@ class ConfigurableProxy extends EventEmitter {
   handleProxy(kind, req, res) {
     // proxy any request
     var that = this;
+
+    // handleProxy is invoked by handleProxyWeb and handleProxyWs, which pass
+    // different arguments to handleProxy.
+    // - handleProxyWeb: args = [req, res]
+    // - handleProxyWs: args = [req, socket, head]
     var args = Array.prototype.slice.call(arguments, 1);
 
     // get the proxy target
@@ -528,7 +533,9 @@ class ConfigurableProxy extends EventEmitter {
         that.handleProxyError(503, kind, req, res, e);
       });
 
-      // dispatch the actual method
+      // dispatch the actual method, either:
+      // - proxy.web(req, res, options, errorHandler)
+      // - proxy.ws(req, socket, head, options, errorHandler)
       that.proxy[kind].apply(that.proxy, args);
 
       // update timestamp on any request/reply data as well (this includes websocket data)
@@ -545,10 +552,10 @@ class ConfigurableProxy extends EventEmitter {
     });
   }
 
-  handleProxyWs(req, res, head) {
+  handleProxyWs(req, socket, head) {
     // Proxy a websocket request
     this.statsd.increment("requests.ws", 1);
-    return this.handleProxy("ws", req, res, head);
+    return this.handleProxy("ws", req, socket, head);
   }
 
   handleProxyWeb(req, res) {


### PR DESCRIPTION
It seems like we use the emit function to trigger potential event
handlers registered, but from what I understand we should do this
differently depending on either proxied web requests and proxied web
socket requests.