### PR TITLE
lib: Use client ssl config to access error target

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -421,7 +421,6 @@ class ConfigurableProxy extends EventEmitter {
     // custom error server gets `/CODE?url=/escapedUrl/`, e.g.
     // /404?url=%2Fuser%2Ffoo
 
-    var proxy = this;
     var errMsg = "";
     this.statsd.increment("requests." + code, 1);
     if (e) {
@@ -439,16 +438,31 @@ class ConfigurableProxy extends EventEmitter {
     }
     this.log.error("%s %s %s %s", code, req.method, req.url, errMsg);
     if (!res) {
+      this.log.debug("Socket error, no response to send");
       // socket-level error, no response to build
       return;
     }
     if (this.errorTarget) {
       var urlSpec = URL.parse(this.errorTarget);
+      // error request is $errorTarget/$code?url=$requestUrl
       urlSpec.search = "?" + querystring.encode({ url: req.url });
       urlSpec.pathname = urlSpec.pathname + code.toString();
       var secure = /https/gi.test(urlSpec.protocol) ? true : false;
       var url = URL.format(urlSpec);
-      var errorRequest = (secure ? https : http).request(url, function (upstream) {
+      this.log.debug("Requesting custom error page: %s", urlSpec.format());
+
+      // construct request target from urlSpec
+      var target = URL.parse(url);
+      target.method = "GET";
+
+      // add client SSL config if error target is using https
+      if (secure && this.options.clientSsl) {
+        target.key = this.options.clientSsl.key;
+        target.cert = this.options.clientSsl.cert;
+        target.ca = this.options.clientSsl.ca;
+      }
+
+      var errorRequest = (secure ? https : http).request(target, function (upstream) {
         ["content-type", "content-encoding"].map(function (key) {
           if (!upstream.headers[key]) return;
           if (res.setHeader) res.setHeader(key, upstream.headers[key]);

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -8,6 +8,8 @@ var WebSocket = require("ws");
 
 var ConfigurableProxy = require("../lib/configproxy").ConfigurableProxy;
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
 describe("Proxy Tests", function () {
   var port = 8902;
   var testPort = port + 10;
@@ -268,10 +270,10 @@ describe("Proxy Tests", function () {
   });
 
   it("custom error target", function (done) {
-    var port = 55555;
+    var proxyPort = 55550;
     util
-      .setupProxy(port, { errorTarget: "http://127.0.0.1:55565" }, [])
-      .then(() => r("http://127.0.0.1:" + port + "/foo/bar"))
+      .setupProxy(proxyPort, { errorTarget: "http://127.0.0.1:55565" }, [])
+      .then(() => r("http://127.0.0.1:" + proxyPort + "/foo/bar"))
       .then((body) => done.fail("Expected 404"))
       .catch((err) => {
         expect(err.statusCode).toEqual(404);
@@ -338,7 +340,7 @@ describe("Proxy Tests", function () {
   });
 
   it("Redirect location with rewriting", function (done) {
-    var proxyPort = 55555;
+    var proxyPort = 55556;
     var options = {
       protocolRewrite: "https",
       autoRewrite: true,


### PR DESCRIPTION
Fixes usage of self-signed certs with Jupyterhub with CHP.
Original issue here:
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1742#issuecomment-671617614