### PR TITLE
simplify dockerignore to exclude node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,2 @@
-# Ignore everything...
-*
-# ... except:
-!bin/
-!lib/
-!chp-docker-entrypoint
-!index.js
-!package*.json
-!LICENSE
+# ignore local assets from development
+node_modules


### PR DESCRIPTION
instead of explicitly including every path

this results in including a few small, not strictly necessary files, but will be much simpler to maintain