### PR TITLE
Security patches of known vulnerabilities in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM node:12.18.3-alpine
+FROM node:lts-alpine3.12
 # ref: https://hub.docker.com/_/node?tab=tags&name=12
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Useful tools for debugging
 RUN apk add --no-cache jq curl
-RUN apk update
-RUN apk add --upgrade libgcc
-RUN apk add --upgrade libstdc++
 
 # Copy relevant (see .dockerignore)
 RUN mkdir -p /srv/configurable-http-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Useful tools for debugging
 RUN apk add --no-cache jq curl
+RUN apk update
+RUN apk add --upgrade libgcc
+RUN apk add --upgrade libstdc++
 
 # Copy relevant (see .dockerignore)
 RUN mkdir -p /srv/configurable-http-proxy


### PR DESCRIPTION
Supports #269 

Running `trivy image --ignore-unfixed --light annas-cool-image:latestt > fixed.txt` (ignore the extra "t" I know how to spell) results in `fixed.txt` output:

```
2020-10-19T10:21:21.830-0500	[34mINFO[0m	Detecting Alpine vulnerabilities...
2020-10-19T10:21:21.831-0500	[34mINFO[0m	Detecting nodejs vulnerabilities...

annas-cool-image:latestt (alpine 3.11.6)
========================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


srv/configurable-http-proxy/package-lock.json
=============================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```