### PR TITLE
docs: update release instructions and readme badges

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: upload-npm
+name: Publish to npm
 
 on:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@
 # - https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow
 # - https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
 
-name: test
+name: Test
 
 on:
   - push

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
 
-[![TravisCI Build status](https://img.shields.io/travis/com/jupyterhub/configurable-http-proxy?logo=travis)](https://travis-ci.com/jupyterhub/configurable-http-proxy)
-[![Docker Build status](https://img.shields.io/docker/build/jupyterhub/configurable-http-proxy?logo=docker&label=build)](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
 [![npm](https://img.shields.io/npm/v/configurable-http-proxy.svg?logo=npm)](https://www.npmjs.com/package/configurable-http-proxy)
+[![Docker Build status](https://img.shields.io/docker/cloud/build/jupyterhub/configurable-http-proxy?logo=docker&label=build)](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/configurable-http-proxy/Test%20chart?logo=github&label=tests)](https://github.com/jupyterhub/configurable-http-proxy/actions)
+[![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/configurable-http-proxy/issues)
+[![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub/z2jh-k8s)
+[![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
 
 **configurable-http-proxy** (CHP) provides you with a way to update and manage
 a proxy table using a command line interface or REST API.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,6 @@ repository as is configured
 
 To make a tagged release follow the instructions below, but first make sure you
 meet the prerequisites:
-- To be a collaborator of the [npmjs
-  project](https://www.npmjs.com/package/configurable-http-proxy).
 - To have push rights to the [configurable-http-proxy GitHub
   repository](https://github.com/jupyterhub/configurable-http-proxy).
 - To have [`bump2version`](https://github.com/c4urself/bump2version) installed
@@ -49,13 +47,6 @@ meet the prerequisites:
    git diff HEAD~1
    ```
 
-1. Publish to NPM.
-
-   ```bash
-   npm login
-   npm publish
-   ```
-
 1. Reset the version to the next development version with `bump2version`.
 
    ```bash
@@ -70,4 +61,38 @@ meet the prerequisites:
 
    ```
    git push --follow-tags $ORIGIN master
+   ```
+
+1. Visit [GitHub: create new
+   release](https://github.com/jupyterhub/configurable-http-proxy/releases/new)
+   and reference your tag.
+
+   This will trigger a workflow to publish the NPM package.
+
+1. Verify [the automated
+   workflow](https://github.com/jupyterhub/configurable-http-proxy/actions?query=workflow%3A%22Publish+to+npm%22)
+   succeeded.
+
+## Manual release to npm
+
+1. Verify you are a collaborator of the [npmjs
+   project](https://www.npmjs.com/package/configurable-http-proxy).
+
+1. Checkout the git tag.
+
+   ```
+   git checkout <tag>
+   ```
+
+1. Cleanup old node_modules etc.
+
+   ```
+   git clean -xfd
+   ```
+
+1. Publish to NPM.
+
+   ```bash
+   npm login
+   npm publish
    ```


### PR DESCRIPTION
Recent travis -> github migration in #275 and made some release instructions outdated and readme badges outdated.