### PR TITLE
Improvements when things go wrong

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -425,15 +425,20 @@ class ConfigurableProxy extends EventEmitter {
     this.statsd.increment("requests." + code, 1);
     if (e) {
       // avoid stack traces on known not-our-problem errors:
-      // ECONNREFUSED (backend isn't there)
-      // ECONNRESET (backend is there, but didn't respond)
-      if (e.code === "ECONNRESET" || e.code === "ECONNREFUSED") {
-        errMsg = e.message;
-      } else {
-        // logging the error object shows a stack trace.
-        // Anything that gets here is an unknown error,
-        // so log more info.
-        errMsg = e;
+      // ECONNREFUSED, EHOSTUNREACH (backend isn't there)
+      // ECONNRESET, ETIMEDOUT (backend is there, but didn't respond)
+      switch (e.code) {
+        case "ECONNREFUSED":
+        case "ECONNRESET":
+        case "EHOSTUNREACH":
+        case "ETIMEDOUT":
+          errMsg = e.message;
+          break;
+        default:
+          // logging the error object shows a stack trace.
+          // Anything that gets here is an unknown error,
+          // so log more info.
+          errMsg = e;
       }
     }
     this.log.error("%s %s %s %s", code, req.method, req.url, errMsg);

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -36,13 +36,15 @@ function argumentsArray(args) {
 function fail(req, res, code, msg) {
   // log a failure, and finish the HTTP request with an error code
   msg = msg || "";
+  res._logMsg = msg;
+
+  if (res.writableEnded) return; // response already done
   if (res.writeHead) res.writeHead(code);
   if (res.write) {
     if (!msg) {
       msg = http.STATUS_CODES[code];
     }
     res.write(msg);
-    res._logMsg = msg;
   }
   if (res.end) res.end();
 }
@@ -410,6 +412,7 @@ class ConfigurableProxy extends EventEmitter {
   _handleProxyErrorDefault(code, kind, req, res) {
     // called when no custom error handler is registered,
     // or is registered and doesn't work
+    if (res.writableEnded) return; // response already done
     if (!res.headersSent && res.writeHead) res.writeHead(code);
     if (res.write) res.write(http.STATUS_CODES[code]);
     if (res.end) res.end();
@@ -468,13 +471,14 @@ class ConfigurableProxy extends EventEmitter {
       }
 
       var errorRequest = (secure ? https : http).request(target, function (upstream) {
+        if (res.writableEnded) return; // response already done
         ["content-type", "content-encoding"].map(function (key) {
           if (!upstream.headers[key]) return;
           if (res.setHeader) res.setHeader(key, upstream.headers[key]);
         });
         if (res.writeHead) res.writeHead(code);
         upstream.on("data", (data) => {
-          if (res.write) res.write(data);
+          if (res.write && !res.writableEnded) res.write(data);
         });
         upstream.on("end", () => {
           if (res.end) res.end();
@@ -503,6 +507,7 @@ class ConfigurableProxy extends EventEmitter {
           this._handleProxyErrorDefault(code, kind, req, res);
           return;
         }
+        if (res.writableEnded) return; // response already done
         if (res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
         if (res.write) res.write(data);
         if (res.end) res.end();


### PR DESCRIPTION
Investigating improvements that could be related to the increase in CHP load on mybinder.org which is currently seeing an increase in routes to stopped endpoints. These are currently giving mostly EHOSTUNREACH, and unhandled `ERR_STREAM_WRITE_AFTER_END` tracebacks, specifically in [this request](https://github.com/jupyterhub/configurable-http-proxy/blob/6792cebc5e2a8d28c258fbd652da1a9370472fa3/lib/configproxy.js#L472) to the upstream error-target provider (jupyterhub).


- avoid write-after-end by checking [res.writableEnded](https://nodejs.org/api/http.html#http_response_writableended) (thanks @betatim).
  This is new in node 12.9, but the falsy behavior when this is undefined for old nodes should be fine, as it will just behave the same as it does now.
- More cases when we don't need to log a traceback for socket issues (EHOSTUNREACH, ETIMEDOUT)