### PR TITLE
adopt pre-commit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  env: {
+    commonjs: true,
+    es6: true,
+    node: true,
+  },
+  extends: "eslint:recommended",
+  parserOptions: {
+    ecmaVersion: 12,
+  },
+  root: true,
+  rules: {
+    "no-unused-vars": "off",
+  },
+};

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,10 @@ jobs:
         run: |
           npm ci
 
-      - name: "`npm run fmt` and check for changes"
-        run: |
-          # If this fails, run `npm run fmt` and push the result
-          # amend if you feel so inclined.
-          npm run fmt
-          git diff --exit-code
+      # Run the pre-commit action
+      # Repo: https://github.com/pre-commit/action
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
 
       - name: npm audit
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-20.04
     # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
     strategy:
-      fail-fast: false  # Do not cancel all jobs if one fails
+      fail-fast: false # Do not cancel all jobs if one fails
       matrix:
         node_version:
           - "10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
           - "--trailing-comma=es5"
           - "--print-width=100"
 
+  # Lint
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.21.0
+    hooks:
+      - id: eslint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  # Autoformat: Bash scripts
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: 6.0.1
+    hooks:
+      - id: beautysh
+
+  # Autoformat: markdown, javacsript
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
+    hooks:
+      - id: prettier
+        args:
+          - "--trailing-comma=es5"
+          - "--print-width=100"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,24 @@ command line for details.
 
 #### Bugs fixed
 
-* lib: Use client ssl config to access error target [#254](https://github.com/jupyterhub/configurable-http-proxy/pull/254) ([@chancez](https://github.com/chancez))
+- lib: Use client ssl config to access error target [#254](https://github.com/jupyterhub/configurable-http-proxy/pull/254) ([@chancez](https://github.com/chancez))
 
 #### Documentation improvements
 
-* docs: update release instructions and readme badges [#285](https://github.com/jupyterhub/configurable-http-proxy/pull/285) ([@consideRatio](https://github.com/consideRatio))
+- docs: update release instructions and readme badges [#285](https://github.com/jupyterhub/configurable-http-proxy/pull/285) ([@consideRatio](https://github.com/consideRatio))
 
 #### Continuous integration
 
-* travis -> github actions [#275](https://github.com/jupyterhub/configurable-http-proxy/pull/275) ([@minrk](https://github.com/minrk))
+- travis -> github actions [#275](https://github.com/jupyterhub/configurable-http-proxy/pull/275) ([@minrk](https://github.com/minrk))
 
 #### Dependency bumps
 
-* Bump ws from 7.4.2 to 7.4.3 [#288](https://github.com/jupyterhub/configurable-http-proxy/pull/288) ([@dependabot](https://github.com/dependabot))
-* Bump ws from 7.4.1 to 7.4.2 [#282](https://github.com/jupyterhub/configurable-http-proxy/pull/282) ([@dependabot](https://github.com/dependabot))
-* Bump ws from 7.4.0 to 7.4.1 [#280](https://github.com/jupyterhub/configurable-http-proxy/pull/280) ([@dependabot](https://github.com/dependabot))
-* Bump ws from 7.3.1 to 7.4.0 [#273](https://github.com/jupyterhub/configurable-http-proxy/pull/273) ([@dependabot](https://github.com/dependabot))
-* Bump commander from 6.2.0 to 6.2.1 [#281](https://github.com/jupyterhub/configurable-http-proxy/pull/281) ([@dependabot](https://github.com/dependabot))
-* Bump commander from 6.1.0 to 6.2.0 [#271](https://github.com/jupyterhub/configurable-http-proxy/pull/271) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.2 to 7.4.3 [#288](https://github.com/jupyterhub/configurable-http-proxy/pull/288) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.1 to 7.4.2 [#282](https://github.com/jupyterhub/configurable-http-proxy/pull/282) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.0 to 7.4.1 [#280](https://github.com/jupyterhub/configurable-http-proxy/pull/280) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.3.1 to 7.4.0 [#273](https://github.com/jupyterhub/configurable-http-proxy/pull/273) ([@dependabot](https://github.com/dependabot))
+- Bump commander from 6.2.0 to 6.2.1 [#281](https://github.com/jupyterhub/configurable-http-proxy/pull/281) ([@dependabot](https://github.com/dependabot))
+- Bump commander from 6.1.0 to 6.2.0 [#271](https://github.com/jupyterhub/configurable-http-proxy/pull/271) ([@dependabot](https://github.com/dependabot))
 
 #### Contributors to this release
 
@@ -40,46 +40,50 @@ command line for details.
 This release contains bugfixes, notably the `--custom-header` implementation.
 
 #### Bugs fixed
-* Emit proxyRequestWs events correctly, and some inline docs [#248](https://github.com/jupyterhub/configurable-http-proxy/pull/248) ([@consideRatio](https://github.com/consideRatio))
-* fix: --custom-header flag implementation [#242](https://github.com/jupyterhub/configurable-http-proxy/pull/242) ([@consideRatio](https://github.com/consideRatio))
-* Fix incorrect this/that on logging statement [#234](https://github.com/jupyterhub/configurable-http-proxy/pull/234) ([@jmartell7](https://github.com/jmartell7))
+
+- Emit proxyRequestWs events correctly, and some inline docs [#248](https://github.com/jupyterhub/configurable-http-proxy/pull/248) ([@consideRatio](https://github.com/consideRatio))
+- fix: --custom-header flag implementation [#242](https://github.com/jupyterhub/configurable-http-proxy/pull/242) ([@consideRatio](https://github.com/consideRatio))
+- Fix incorrect this/that on logging statement [#234](https://github.com/jupyterhub/configurable-http-proxy/pull/234) ([@jmartell7](https://github.com/jmartell7))
 
 #### Maintenance and upkeep improvements
-* Security patches of known vulnerabilities in docker image [#270](https://github.com/jupyterhub/configurable-http-proxy/pull/270) ([@wongannaw](https://github.com/wongannaw))
-* try dependabot for updates [#256](https://github.com/jupyterhub/configurable-http-proxy/pull/256) ([@minrk](https://github.com/minrk))
-* simplify dockerignore to exclude node_modules [#255](https://github.com/jupyterhub/configurable-http-proxy/pull/255) ([@minrk](https://github.com/minrk))
-* CI: npm audit cronjob details [#246](https://github.com/jupyterhub/configurable-http-proxy/pull/246) ([@consideRatio](https://github.com/consideRatio))
-* Docker image: use package-lock.json and only include relevant parts [#241](https://github.com/jupyterhub/configurable-http-proxy/pull/241) ([@consideRatio](https://github.com/consideRatio))
-* CI: fix .travis.yml syntax for cronjob [#240](https://github.com/jupyterhub/configurable-http-proxy/pull/240) ([@consideRatio](https://github.com/consideRatio))
-* CI: npm-audit cronjob in travis [#239](https://github.com/jupyterhub/configurable-http-proxy/pull/239) ([@consideRatio](https://github.com/consideRatio))
-* CI: test against node 14 [#237](https://github.com/jupyterhub/configurable-http-proxy/pull/237) ([@consideRatio](https://github.com/consideRatio))
-* Stop installing development dependencies in Docker image [#227](https://github.com/jupyterhub/configurable-http-proxy/pull/227) ([@consideRatio](https://github.com/consideRatio))
+
+- Security patches of known vulnerabilities in docker image [#270](https://github.com/jupyterhub/configurable-http-proxy/pull/270) ([@wongannaw](https://github.com/wongannaw))
+- try dependabot for updates [#256](https://github.com/jupyterhub/configurable-http-proxy/pull/256) ([@minrk](https://github.com/minrk))
+- simplify dockerignore to exclude node_modules [#255](https://github.com/jupyterhub/configurable-http-proxy/pull/255) ([@minrk](https://github.com/minrk))
+- CI: npm audit cronjob details [#246](https://github.com/jupyterhub/configurable-http-proxy/pull/246) ([@consideRatio](https://github.com/consideRatio))
+- Docker image: use package-lock.json and only include relevant parts [#241](https://github.com/jupyterhub/configurable-http-proxy/pull/241) ([@consideRatio](https://github.com/consideRatio))
+- CI: fix .travis.yml syntax for cronjob [#240](https://github.com/jupyterhub/configurable-http-proxy/pull/240) ([@consideRatio](https://github.com/consideRatio))
+- CI: npm-audit cronjob in travis [#239](https://github.com/jupyterhub/configurable-http-proxy/pull/239) ([@consideRatio](https://github.com/consideRatio))
+- CI: test against node 14 [#237](https://github.com/jupyterhub/configurable-http-proxy/pull/237) ([@consideRatio](https://github.com/consideRatio))
+- Stop installing development dependencies in Docker image [#227](https://github.com/jupyterhub/configurable-http-proxy/pull/227) ([@consideRatio](https://github.com/consideRatio))
 
 #### Documentation improvements
-* Documentation changes #235 [#236](https://github.com/jupyterhub/configurable-http-proxy/pull/236) ([@suryag10](https://github.com/suryag10))
+
+- Documentation changes #235 [#236](https://github.com/jupyterhub/configurable-http-proxy/pull/236) ([@suryag10](https://github.com/suryag10))
 
 #### Dependency bumps
-* Bump jasmine from 3.6.1 to 3.6.2 [#268](https://github.com/jupyterhub/configurable-http-proxy/pull/268) ([@dependabot](https://github.com/dependabot))
-* Bump prettier from 2.1.1 to 2.1.2 [#266](https://github.com/jupyterhub/configurable-http-proxy/pull/266) ([@dependabot](https://github.com/dependabot))
-* Bump request from 2.88.0 to 2.88.2 [#265](https://github.com/jupyterhub/configurable-http-proxy/pull/265) ([@dependabot](https://github.com/dependabot))
-* Bump ws from 7.3.0 to 7.3.1 [#264](https://github.com/jupyterhub/configurable-http-proxy/pull/264) ([@dependabot](https://github.com/dependabot))
-* Bump request-promise-native from 1.0.5 to 1.0.9 [#263](https://github.com/jupyterhub/configurable-http-proxy/pull/263) ([@dependabot](https://github.com/dependabot))
-* Bump prettier from 2.0.0 to 2.1.1 [#262](https://github.com/jupyterhub/configurable-http-proxy/pull/262) ([@dependabot](https://github.com/dependabot))
-* Bump nyc from 15.0.0 to 15.1.0 [#261](https://github.com/jupyterhub/configurable-http-proxy/pull/261) ([@dependabot](https://github.com/dependabot))
-* Bump jasmine from 3.5.0 to 3.6.1 [#260](https://github.com/jupyterhub/configurable-http-proxy/pull/260) ([@dependabot](https://github.com/dependabot))
-* Bump commander from 5.1.0 to 6.1.0 [#259](https://github.com/jupyterhub/configurable-http-proxy/pull/259) ([@dependabot](https://github.com/dependabot))
-* Bump jshint from 2.10.2 to 2.12.0 [#258](https://github.com/jupyterhub/configurable-http-proxy/pull/258) ([@dependabot](https://github.com/dependabot))
-* Bump winston from 3.3.0 to 3.3.3 [#257](https://github.com/jupyterhub/configurable-http-proxy/pull/257) ([@dependabot](https://github.com/dependabot))
-* Update node Docker tag to v12.18.3 [#253](https://github.com/jupyterhub/configurable-http-proxy/pull/253) ([@renovate](https://github.com/renovate))
-* Bump lodash from 4.17.15 to 4.17.19 [#250](https://github.com/jupyterhub/configurable-http-proxy/pull/250) ([@dependabot](https://github.com/dependabot))
-* chore(deps): update dependency ws to v7 [#247](https://github.com/jupyterhub/configurable-http-proxy/pull/247) ([@renovate](https://github.com/renovate))
-* Update dependency winston to ~3.3.0 [#245](https://github.com/jupyterhub/configurable-http-proxy/pull/245) ([@renovate](https://github.com/renovate))
-* Update node Docker tag to v12.18.2 [#243](https://github.com/jupyterhub/configurable-http-proxy/pull/243) ([@renovate](https://github.com/renovate))
-* Deps: npm audit fix to bump patch versions [#238](https://github.com/jupyterhub/configurable-http-proxy/pull/238) ([@consideRatio](https://github.com/consideRatio))
-* Update node Docker tag to v12.17.0 [#233](https://github.com/jupyterhub/configurable-http-proxy/pull/233) ([@renovate](https://github.com/renovate))
-* Update node Docker tag to v12.16.3 [#231](https://github.com/jupyterhub/configurable-http-proxy/pull/231) ([@renovate](https://github.com/renovate))
-* Update dependency prettier to v2 [#230](https://github.com/jupyterhub/configurable-http-proxy/pull/230) ([@renovate](https://github.com/renovate))
-* Update dependency commander to v5 [#229](https://github.com/jupyterhub/configurable-http-proxy/pull/229) ([@renovate](https://github.com/renovate))
+
+- Bump jasmine from 3.6.1 to 3.6.2 [#268](https://github.com/jupyterhub/configurable-http-proxy/pull/268) ([@dependabot](https://github.com/dependabot))
+- Bump prettier from 2.1.1 to 2.1.2 [#266](https://github.com/jupyterhub/configurable-http-proxy/pull/266) ([@dependabot](https://github.com/dependabot))
+- Bump request from 2.88.0 to 2.88.2 [#265](https://github.com/jupyterhub/configurable-http-proxy/pull/265) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.3.0 to 7.3.1 [#264](https://github.com/jupyterhub/configurable-http-proxy/pull/264) ([@dependabot](https://github.com/dependabot))
+- Bump request-promise-native from 1.0.5 to 1.0.9 [#263](https://github.com/jupyterhub/configurable-http-proxy/pull/263) ([@dependabot](https://github.com/dependabot))
+- Bump prettier from 2.0.0 to 2.1.1 [#262](https://github.com/jupyterhub/configurable-http-proxy/pull/262) ([@dependabot](https://github.com/dependabot))
+- Bump nyc from 15.0.0 to 15.1.0 [#261](https://github.com/jupyterhub/configurable-http-proxy/pull/261) ([@dependabot](https://github.com/dependabot))
+- Bump jasmine from 3.5.0 to 3.6.1 [#260](https://github.com/jupyterhub/configurable-http-proxy/pull/260) ([@dependabot](https://github.com/dependabot))
+- Bump commander from 5.1.0 to 6.1.0 [#259](https://github.com/jupyterhub/configurable-http-proxy/pull/259) ([@dependabot](https://github.com/dependabot))
+- Bump jshint from 2.10.2 to 2.12.0 [#258](https://github.com/jupyterhub/configurable-http-proxy/pull/258) ([@dependabot](https://github.com/dependabot))
+- Bump winston from 3.3.0 to 3.3.3 [#257](https://github.com/jupyterhub/configurable-http-proxy/pull/257) ([@dependabot](https://github.com/dependabot))
+- Update node Docker tag to v12.18.3 [#253](https://github.com/jupyterhub/configurable-http-proxy/pull/253) ([@renovate](https://github.com/renovate))
+- Bump lodash from 4.17.15 to 4.17.19 [#250](https://github.com/jupyterhub/configurable-http-proxy/pull/250) ([@dependabot](https://github.com/dependabot))
+- chore(deps): update dependency ws to v7 [#247](https://github.com/jupyterhub/configurable-http-proxy/pull/247) ([@renovate](https://github.com/renovate))
+- Update dependency winston to ~3.3.0 [#245](https://github.com/jupyterhub/configurable-http-proxy/pull/245) ([@renovate](https://github.com/renovate))
+- Update node Docker tag to v12.18.2 [#243](https://github.com/jupyterhub/configurable-http-proxy/pull/243) ([@renovate](https://github.com/renovate))
+- Deps: npm audit fix to bump patch versions [#238](https://github.com/jupyterhub/configurable-http-proxy/pull/238) ([@consideRatio](https://github.com/consideRatio))
+- Update node Docker tag to v12.17.0 [#233](https://github.com/jupyterhub/configurable-http-proxy/pull/233) ([@renovate](https://github.com/renovate))
+- Update node Docker tag to v12.16.3 [#231](https://github.com/jupyterhub/configurable-http-proxy/pull/231) ([@renovate](https://github.com/renovate))
+- Update dependency prettier to v2 [#230](https://github.com/jupyterhub/configurable-http-proxy/pull/230) ([@renovate](https://github.com/renovate))
+- Update dependency commander to v5 [#229](https://github.com/jupyterhub/configurable-http-proxy/pull/229) ([@renovate](https://github.com/renovate))
 
 #### Contributors to this release
 
@@ -125,8 +129,8 @@ configurable-http-proxy, which itself was left untouched.
 - chore(deps): update dependency nyc to v14 [#202](https://github.com/jupyterhub/configurable-http-proxy/pull/202) ([@renovate](https://github.com/renovate))
 - Update dependency commander to ~2.20.0 [#201](https://github.com/jupyterhub/configurable-http-proxy/pull/201) ([@renovate](https://github.com/renovate))
 
-
 ### [4.1]
+
 ### [4.1.0] - 2019-04-01
 
 - Add `--redirect-to` option to specify destination port when redirecting
@@ -134,7 +138,6 @@ configurable-http-proxy, which itself was left untouched.
 - Add health check endpoint at `/_chp_healthz`.
 - Docker base image is updated to `node/10-alpine` from `node/6-alpine`
 - Dependencies are updated via Renovate
-
 
 ## [4.0]
 
@@ -209,13 +212,12 @@ Improvements:
 
 **Added:**
 
-- Add configuration option for proxy timeout `--proxy-timeout <n>, Timeout
-  (in millis) when proxy receives no response from target.`
+- Add configuration option for proxy timeout `--proxy-timeout <n>, Timeout (in millis) when proxy receives no response from target.`
   [\#86](https://github.com/jupyterhub/configurable-http-proxy/pull/86)
 - Add configuration options for auto rewrite and protocol rewrite
   [\#73](https://github.com/jupyterhub/configurable-http-proxy/pull/73):
-    - `--auto-rewrite, Rewrite the Location header host/port in redirect responses`
-    - `--protocol-rewrite <proto>', Rewrite the Location header protocol in redirect responses to the specified protocol`
+  - `--auto-rewrite, Rewrite the Location header host/port in redirect responses`
+  - `--protocol-rewrite <proto>', Rewrite the Location header protocol in redirect responses to the specified protocol`
 - Add low-level code for separate stores of routes to enable future support of other data stores such as Redis [\#81](https://github.com/jupyterhub/configurable-http-proxy/pull/81)
 
 **Changed:**
@@ -227,7 +229,7 @@ Improvements:
 
 - Fix behavior to correctly handle children when a parent node is deleted [\#93](https://github.com/jupyterhub/configurable-http-proxy/pull/93)
 - Fix closure reference when serving custom error pages [\#91](https://github.com/jupyterhub/configurable-http-proxy/pull/91)
-- Improved all-interfaces warning message when `ip='*'`  [\#94](https://github.com/jupyterhub/configurable-http-proxy/pull/94)
+- Improved all-interfaces warning message when `ip='*'` [\#94](https://github.com/jupyterhub/configurable-http-proxy/pull/94)
 
 ## [1.3]
 
@@ -279,7 +281,7 @@ Improvements:
 
 ## [0.1.1] - 2014-10-01
 
-[Unreleased]: https://github.com/jupyterhub/configurable-http-proxy/compare/4.1.0...HEAD
+[unreleased]: https://github.com/jupyterhub/configurable-http-proxy/compare/4.1.0...HEAD
 [4.1]: https://github.com/jupyterhub/configurable-http-proxy/compare/4.0.1...4.1.0
 [4.0]: https://github.com/jupyterhub/configurable-http-proxy/compare/3.1.1...4.0.1
 [3.1.1]: https://github.com/jupyterhub/configurable-http-proxy/compare/3.1.0...3.1.1

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ functionality to [JupyterHub] deployments.
 
 - [Install](#install)
 - [Usage](#usage)
-    - [Starting the proxy](#starting-the-proxy)
-    - [Setting a default target](#setting-a-default-target)
-    - [Command-line options](#command-line-options)
+  - [Starting the proxy](#starting-the-proxy)
+  - [Setting a default target](#setting-a-default-target)
+  - [Command-line options](#command-line-options)
 - [Using the REST API](#using-the-rest-api)
-    - [REST API Basics](#REST-api-basics)
-    - [Authenticating via passing a token](#authenticating-via-passing-a-token)
-    - [Getting the routing table](#getting-the-routing-table)
-    - [Adding new routes](#adding-new-routes)
-    - [Deleting routes](#deleting-routes)
+  - [REST API Basics](#REST-api-basics)
+  - [Authenticating via passing a token](#authenticating-via-passing-a-token)
+  - [Getting the routing table](#getting-the-routing-table)
+  - [Adding new routes](#adding-new-routes)
+  - [Deleting routes](#deleting-routes)
 - [Custom error pages](#custom-error-pages)
 - [Host-based routing](#host-based-routing)
 - [Troubleshooting](#troubleshooting)
@@ -49,7 +49,7 @@ To install from the source code found in this GitHub repo:
 
 ```bash
 git clone https://github.com/jupyterhub/configurable-http-proxy
-cd configurable-http-proxy 
+cd configurable-http-proxy
 npm install  # Use 'npm install -g' for global install
 ```
 
@@ -60,12 +60,12 @@ npm install  # Use 'npm install -g' for global install
 The configurable proxy runs two HTTP(S) servers:
 
 - The **public-facing interface** to your application (controlled by `--ip`,
-   `--port`)
-    - listens on **all interfaces** by default.
+  `--port`)
+  - listens on **all interfaces** by default.
 - The **inward-facing REST API** (`--api-ip`, `--api-port`)
-    - listens on localhost by default
-    - The REST API uses token authorization, where the token is set in the
-      `CONFIGPROXY_AUTH_TOKEN` environment variable.
+  - listens on localhost by default
+  - The REST API uses token authorization, where the token is set in the
+    `CONFIGPROXY_AUTH_TOKEN` environment variable.
 
 ![](./doc/_static/chp.png)
 
@@ -161,8 +161,9 @@ Options:
 ## Using the REST API
 
 The configurable-http-proxy REST API is documented and available as:
+
 - a nicely rendered, interactive version at the
-[petstore swagger site][]
+  [petstore swagger site][]
 - a [swagger specification file][] in this repo
 
 [**Return to top**][]
@@ -172,14 +173,13 @@ The configurable-http-proxy REST API is documented and available as:
 **API Root**
 
 | HTTP method | Endpoint | Function |
-|-------------|----------|----------|
+| ----------- | -------- | -------- |
 | GET         | /api/    | API Root |
-
 
 **Routes**
 
 | HTTP method | Endpoint                 | Function                            |
-|-------------|--------------------------|-------------------------------------|
+| ----------- | ------------------------ | ----------------------------------- |
 | GET         | /api/routes              | [Get all routes in routing table][] |
 | POST        | /api/routes/{route_spec} | [Add a new route][]                 |
 | DELETE      | /api/routes/{route_spec} | [Remove the given route][]          |
@@ -208,7 +208,6 @@ curl -H "Authorization: token $CONFIGPROXY_AUTH_TOKEN" http://localhost:8001/api
 
     GET /api/routes[?inactive_since=ISO8601-timestamp]
 
-
 **Parameters:**
 
 `inactive_since`: If the `inactive_since` URL
@@ -219,14 +218,14 @@ passes data to or from the proxy target.
 
 **Response:**
 
-*Status code*
+_Status code_
 
     status: 200 OK
 
-*Response body*
+_Response body_
 
 A JSON dictionary of the current routing table. This JSON
-dictionary *excludes* the default route.
+dictionary _excludes_ the default route.
 
 **Behavior:**
 
@@ -249,6 +248,7 @@ dictionary with at least one key: `target`, the target host to be proxied.
 `target`: The host URL
 
 Example request body:
+
 ```json
 {
   "target": "http://localhost:8002"
@@ -292,7 +292,7 @@ hit, along with their status code:
   routing target. This error **can be prevented** by setting a
   [`default target`][] before starting the configurable-http-proxy.
 
-- 503 error: Returned when a route exists, but the upstream server isn't 
+- 503 error: Returned when a route exists, but the upstream server isn't
   responding. This is more common, and can be due to any number of reasons,
   including the target service having died, not finished starting, or network
   instability.
@@ -364,17 +364,14 @@ Q: My proxy is not starting. What could be happening?
   that is very old, and it is necessary to update node to a recent or `LTS`
   version.
 
-
 [**Return to top**][]
 
-
-
 [node-http-proxy]: https://github.com/nodejitsu/node-http-proxy
-[JupyterHub]: https://github.com/jupyterhub/jupyterhub
+[jupyterhub]: https://github.com/jupyterhub/jupyterhub
 [petstore swagger site]: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/configurable-http-proxy/master/doc/rest-api.yml#/default
 [swagger specification file]: https://github.com/jupyterhub/configurable-http-proxy/blob/master/doc/rest-api.yml
-[Get all routes in routing table]: #getting-the-routing-table
-[Add a new route]: #adding-new-routes
-[Remove the given route]: #deleting-routes
+[get all routes in routing table]: #getting-the-routing-table
+[add a new route]: #adding-new-routes
+[remove the given route]: #deleting-routes
 [`default target`]: #setting-a-default-target
-[**Return to top**]: #table-of-contents
+[**return to top**]: #table-of-contents

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ repository as is configured
 
 To make a tagged release follow the instructions below, but first make sure you
 meet the prerequisites:
+
 - To have push rights to the [configurable-http-proxy GitHub
   repository](https://github.com/jupyterhub/configurable-http-proxy).
 - To have [`bump2version`](https://github.com/c4urself/bump2version) installed

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -160,6 +160,22 @@ if (args.sslCiphers) {
   ].join(":");
 }
 
+function _loadSslCa(caFile) {
+  // When multiple CAs need to be specified, they must be broken into
+  // an array of certs unfortunately.
+  var chain = fs.readFileSync(caFile, "utf8");
+  var ca = [];
+  var cert = [];
+  chain.split("\n").forEach(function (line) {
+    cert.push(line);
+    if (line.match(/-END CERTIFICATE-/)) {
+      ca.push(new Buffer(cert.join("\n")));
+      cert = [];
+    }
+  });
+  return ca;
+}
+
 // ssl options
 if (args.sslKey || args.sslCert) {
   options.ssl = {};
@@ -200,19 +216,7 @@ if (args.apiSslKey || args.apiSslCert) {
     options.apiSsl.cert = fs.readFileSync(args.apiSslCert);
   }
   if (args.apiSslCa) {
-    // When multiple CAs need to be specified, they must be broken into
-    // an array of certs unfortunately.
-    var chain = fs.readFileSync(args.apiSslCa, "utf8");
-    var ca = [];
-    var cert = [];
-    chain.split("\n").forEach(function (line) {
-      cert.push(line);
-      if (line.match(/-END CERTIFICATE-/)) {
-        ca.push(new Buffer(cert.join("\n")));
-        cert = [];
-      }
-    });
-    options.apiSsl.ca = ca;
+    options.apiSsl.ca = _loadSslCa(args.apiSslCa);
   }
   if (args.sslDhparam) {
     options.apiSsl.dhparam = fs.readFileSync(args.sslDhparam);
@@ -235,19 +239,7 @@ if (args.clientSslKey || args.clientSslCert) {
     options.clientSsl.cert = fs.readFileSync(args.clientSslCert);
   }
   if (args.clientSslCa) {
-    // When multiple CAs need to be specified, they must be broken into
-    // an array of certs unfortunately.
-    var chain = fs.readFileSync(args.clientSslCa, "utf8");
-    var ca = [];
-    var cert = [];
-    chain.split("\n").forEach(function (line) {
-      cert.push(line);
-      if (line.match(/-END CERTIFICATE-/)) {
-        ca.push(new Buffer(cert.join("\n")));
-        cert = [];
-      }
-    });
-    options.clientSsl.ca = ca;
+    options.clientSsl.ca = _loadSslCa(args.clientSslCa);
   }
   if (args.sslDhparam) {
     options.clientSsl.dhparam = fs.readFileSync(args.sslDhparam);

--- a/chp-docker-entrypoint
+++ b/chp-docker-entrypoint
@@ -7,38 +7,38 @@
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
 #  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 file_env() {
-  var=$1
-  file_var="${var}_FILE"
-  var_value=$(printenv $var || true)
-  file_var_value=$(printenv $file_var || true)
-  default_value=$2
+    var=$1
+    file_var="${var}_FILE"
+    var_value=$(printenv $var || true)
+    file_var_value=$(printenv $file_var || true)
+    default_value=$2
 
-  if [ -n "$var_value" -a -n "$file_var_value" ]; then
-    echo >&2 "error: both $var and $file_var are set (but are exclusive)"
-    exit 1
-  fi
-
-  if [ -z "${var_value}" ]; then
-    if [ -z "${file_var_value}" ]; then
-      export "${var}"="${default_value}"
-    else
-      export "${var}"="$(cat $file_var_value)"
+    if [ -n "$var_value" -a -n "$file_var_value" ]; then
+        echo >&2 "error: both $var and $file_var are set (but are exclusive)"
+        exit 1
     fi
-  fi
 
-  unset "$file_var"
+    if [ -z "${var_value}" ]; then
+        if [ -z "${file_var_value}" ]; then
+            export "${var}"="${default_value}"
+        else
+            export "${var}"="$(cat $file_var_value)"
+        fi
+    fi
+
+    unset "$file_var"
 }
 
 file_env 'CONFIGPROXY_AUTH_TOKEN'
 
 case "$@" in
-  *"--api-ip"*)
-    break;;
-  *)
-    # Default api-ip to all interfaces in docker,
-    # so that it is accessible to other containers
-    # and when port-forwarding is requested.
-    ARGS="--api-ip=0.0.0.0";;
+    *"--api-ip"*)
+        break ;;
+    *)
+        # Default api-ip to all interfaces in docker,
+        # so that it is accessible to other containers
+        # and when port-forwarding is requested.
+        ARGS="--api-ip=0.0.0.0" ;;
 esac
 
 exec configurable-http-proxy $ARGS "$@"

--- a/doc/rest-api.yml
+++ b/doc/rest-api.yml
@@ -37,7 +37,7 @@ paths:
         200:
           description: "The routing table"
           schema:
-            $ref: '#/definitions/RoutingTable'
+            $ref: "#/definitions/RoutingTable"
         400:
           description: "Invalid timestamp provided"
         404:
@@ -84,7 +84,7 @@ definitions:
     type: "object"
     description: "Maps keys (route path prefixes / hostnames) to their targets"
     additionalProperties:
-      $ref: '#/definitions/RouteTarget'
+      $ref: "#/definitions/RouteTarget"
   RouteTarget:
     type: "object"
     properties:

--- a/lib/error/404.html
+++ b/lib/error/404.html
@@ -1,14 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>404: Not Found</title>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>404: Not Found</title>
+  </head>
 
-<body>
-  <h1>404: Not Found</h1>
-  <p>No service is registered at this URL</p>
-  <hr/>
-  <p>configurable-http-proxy</p>
-</body>
+  <body>
+    <h1>404: Not Found</h1>
+    <p>No service is registered at this URL</p>
+    <hr />
+    <p>configurable-http-proxy</p>
+  </body>
 </html>

--- a/lib/error/503.html
+++ b/lib/error/503.html
@@ -1,14 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>503: Proxy Target Missing</title>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>503: Proxy Target Missing</title>
+  </head>
 
-<body>
-  <h1>503: Proxy Target Missing</h1>
-  <p>The upstream service is unavailable</p>
-  <hr/>
-  <p>configurable-http-proxy</p>
-</body>
+  <body>
+    <h1>503: Proxy Target Missing</h1>
+    <p>The upstream service is unavailable</p>
+    <hr />
+    <p>configurable-http-proxy</p>
+  </body>
 </html>

--- a/lib/error/error.html
+++ b/lib/error/error.html
@@ -1,13 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Proxy Error</title>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <title>Proxy Error</title>
+  </head>
 
-<body>
-  <h1>Proxy Error</h1>
-  <hr/>
-  <p>configurable-http-proxy</p>
-</body>
+  <body>
+    <h1>Proxy Error</h1>
+    <hr />
+    <p>configurable-http-proxy</p>
+  </body>
 </html>

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -31,7 +31,7 @@ function URLTrie(prefix) {
   this.size = 0;
 }
 
-var _slashesRe = /^[\/]+|[\/]+$/g;
+var _slashesRe = /^[/]+|[/]+$/g;
 function stringToPath(s) {
   // turn a /prefix/string/ into ['prefix', 'string']
   s = s.replace(_slashesRe, "");
@@ -55,7 +55,7 @@ URLTrie.prototype.add = function (path, data) {
     return;
   }
   var part = path.shift();
-  if (!this.branches.hasOwnProperty(part)) {
+  if (!Object.prototype.hasOwnProperty.call(this.branches, part)) {
     // join with /, and handle the fact that only root ends with '/'
     var prefix = this.prefix.length === 1 ? this.prefix : this.prefix + "/";
     this.branches[part] = new URLTrie(prefix + part);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "jasmine": "^3.5.0",
     "jshint": "^2.10.2",
     "nyc": "^15.0.0",
-    "prettier": "^2.0.0",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.4",
     "ws": "^7.0.0"
@@ -40,7 +39,7 @@
   },
   "scripts": {
     "lint": "jshint bin/ lib/ test/",
-    "fmt": "prettier --write *.js bin/* lib/*.js test/*.js --trailing-comma es5 --print-width 100",
+    "fmt": "pre-commit run --all-files",
     "test": "nyc jasmine JASMINE_CONFIG_PATH=test/jasmine.json",
     "coverage-html": "nyc report --reporter=html",
     "codecov": "nyc report --reporter=lcov && codecov"

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    jasmine: true,
+  },
+};


### PR DESCRIPTION
- replaces `npm run fmt` which ran prettier on js
- autoformat html, markdown, yaml, scripts, not just js
- adds `eslint` and address a couple linter messages

The only reason *not* to do this is because pre-commit is a Python package and the js-community generally uses [husky](https://typicode.github.io/husky) to do things like pre-commit hooks.

On the other hand, the rest of JupyterHub uses pre-commit, and that's who contributes here.