### PR TITLE
Do not update activity on failed requests

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -130,6 +130,11 @@ const loadStorage = (options) => {
   return new store.MemoryStore(options);
 };
 
+function _logUrl(url) {
+  // format a url for logging, e.g. strip url params
+  if (url) return url.split("?", 1)[0];
+}
+
 class ConfigurableProxy extends EventEmitter {
   constructor(options) {
     super();
@@ -198,7 +203,7 @@ class ConfigurableProxy extends EventEmitter {
     var logErrors = (handler) => {
       return function (req, res) {
         function logError(e) {
-          that.log.error("Error in handler for " + req.method + " " + req.url + ": %s", e);
+          that.log.error("Error in handler for %s %s: %s", req.method, _logUrl(req.url), e);
         }
         try {
           let p = handler.apply(that, arguments);
@@ -246,7 +251,7 @@ class ConfigurableProxy extends EventEmitter {
       logF = this.log.error;
     }
     var msg = res._logMsg || "";
-    logF("%s %s %s %s", code, req.method.toUpperCase(), req.url, msg);
+    logF("%s %s %s %s", code, req.method.toUpperCase(), _logUrl(req.url), msg);
   }
 
   addRoute(path, data) {
@@ -444,7 +449,7 @@ class ConfigurableProxy extends EventEmitter {
           errMsg = e;
       }
     }
-    this.log.error("%s %s %s %s", code, req.method, req.url, errMsg);
+    this.log.error("%s %s %s %s", code, req.method, _logUrl(req.url), errMsg);
     if (!res) {
       this.log.debug("Socket error, no response to send");
       // socket-level error, no response to build
@@ -541,7 +546,7 @@ class ConfigurableProxy extends EventEmitter {
       }
       var prefix = match.prefix;
       var target = match.target;
-      that.log.debug("PROXY %s %s to %s", kind.toUpperCase(), req.url, target);
+      that.log.debug("PROXY %s %s to %s", kind.toUpperCase(), _logUrl(req.url), target);
       if (!that.includePrefix) {
         req.url = req.url.slice(prefix.length);
       }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -580,8 +580,24 @@ class ConfigurableProxy extends EventEmitter {
         that.updateLastActivity(prefix);
       });
 
-      // update last activity timestamp in routing table
-      return that.updateLastActivity(prefix);
+      if (kind === "web") {
+        // update last activity on completion of the request
+        // only consider 'successful' requests activity
+        // A flood of invalid requests such as 404s or 403s
+        // or 503s because the endpoint is down
+        // shouldn't make it look like the endpoint is 'active'
+
+        // we no longer register activity at the *start* of the request
+        // because at that point we don't know if the endpoint is even available
+        res.on("finish", function () {
+          // (don't count redirects...but should we?)
+          if (res.statusCode < 300) {
+            that.updateLastActivity(prefix);
+          } else {
+            that.log.debug("Not recording activity for status %s on %s", res.statusCode, prefix);
+          }
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Up to now, we mark activity for any *attempt* to talk to an endpoint, by updating the activity timestamp when any request is initiated.

This means that an endpoint that isn't even running anymore (503 errors) will register activity if someone is trying to talk to it.

This moves the activity update to the response `finish` event, which is when the request completes. This lets us take the status code into account, and only consider 'successful' (status < 300) requests to be activity.

Consequences:

- a server that is unavailable (always status 503) will not appear 'active'
- spurious requests (e.g. lots of 404s because the endpoint isn't what is expected) no longer count as activity
- borderline: redirects (3XX) are not counted either, which I think is right because we can assume a redirect will result in a second request to the same server that will be either successful or a failure, and thus accounted for on the retry. If it is not retried, or if the 'right' destination is another service, this shouldn't be considered 'activity'.
- Activity is registered slightly later - at the end of requests rather than the beginning
- Opening a websocket will not register as activity until a first message is sent or received

The last two points mean that there can technically be a delay (usually at most 30 seconds due to various socket timeouts) between when activity is initiated and when it is registered. However, the same change also means that the 'last' activity timeout is also more accurate - more closely aligning with the end of the transaction than the beginning.

This additionally tweaks logging to omit url params, which are not relevant to the proxy.