### PR TITLE
Add tests for last-activity updates

### DIFF
--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -45,7 +45,11 @@ var addTarget = (exports.addTarget = function (proxy, path, port, websocket, tar
 
   server.listen(port);
   servers.push(server);
-  return proxy.addRoute(path, { target: target });
+  return proxy.addRoute(path, { target: target }).then(() => {
+    // routes are created with an activity timestamp artificially shifted into the past
+    // so that activity can more easily be measured
+    return proxy._routes.update(path, { last_activity: proxy._setup_timestamp });
+  });
 });
 
 var addTargetRedirecting = (exports.addTargetRedirecting = function (
@@ -90,6 +94,7 @@ exports.setupProxy = function (port, options, paths) {
   options.log = defaultLogger({ level: "error" });
 
   var proxy = new configproxy.ConfigurableProxy(options);
+  proxy._setup_timestamp = new Date(new Date().getTime() - 60000);
   var ip = "127.0.0.1";
   var countdown = 2;
   var resolvePromise;


### PR DESCRIPTION
tests for #292 - both that the usual activity is unchanged for simple successful requests, and that activity is *not* updated for failed requests