### PR TITLE
Build and publish Docker Hub image for amd64 and arm64

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ name: Publish to npm
 
 on:
   push:
+  pull_request:
     tags: ["[0-9]+.[0-9]+.[0-9]+*"]
 
 jobs:
@@ -20,3 +21,42 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+
+  publish-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # https://github.com/docker/login-action/tree/v1.8.0#docker-hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # https://github.com/manics/action-major-minor-tag-calculator-test
+      - name: Get list of tags
+        id: gettags
+        # TODO: Move to org?
+        uses: manics/action-major-minor-tag-calculator@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          prefix: "manics/action-major-minor-tag-calculator-test:"
+
+      - name: Display tags
+        run: echo "Docker tags ${{ steps.gettags.outputs.tags }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: images/${{ matrix.image }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Setup docker to build for multiple platforms (requires qemu).
+      # See:
+      # https://github.com/docker/build-push-action/tree/v2.3.0#usage
+      # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -43,13 +48,19 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # https://github.com/manics/action-major-minor-tag-calculator-test
+      # If this is a tagged build this will return additional parent tags.
+      # E.g. 1.2.3 is expanded to Docker tags
+      # [{prefix}:1.2.3, {prefix}:1.2, {prefix}:1, {prefix}:latest] unless
+      # this is a backported tag in which case the newer tags aren't updated.
+      # For branches this will return the branch name.
+      # If GITHUB_TOKEN isn't available (e.g. in PRs) returns no tags [].
       - name: Get list of tags
         id: gettags
         # TODO: Move to org?
         uses: manics/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          prefix: "manics/action-major-minor-tag-calculator-test:"
+          prefix: "jupyterhub/configurable-http-proxy:"
 
       - name: Display tags
         run: echo "Docker tags ${{ steps.gettags.outputs.tags }}"
@@ -59,4 +70,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          # tags parameter must be a string input so convert `gettags` JSON
+          # array into a comma separated list of tags
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: images/${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # https://github.com/manics/action-major-minor-tag-calculator-test
+      # https://github.com/jupyterhub/action-major-minor-tag-calculator
       # If this is a tagged build this will return additional parent tags.
       # E.g. 1.2.3 is expanded to Docker tags
       # [{prefix}:1.2.3, {prefix}:1.2, {prefix}:1, {prefix}:latest] unless
@@ -57,7 +57,7 @@ jobs:
       - name: Get list of tags
         id: gettags
         # TODO: Move to org?
-        uses: manics/action-major-minor-tag-calculator@main
+        uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "jupyterhub/configurable-http-proxy:"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,14 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
-name: Publish to npm
+# Publish NPM package and Docker image
+name: Release
 
 on:
   push:
   pull_request:
 
 jobs:
+  # Run tests using node, publish a package when tagged
+  # https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
   publish-npm:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ name: Publish to npm
 on:
   push:
   pull_request:
-    tags: ["[0-9]+.[0-9]+.[0-9]+*"]
 
 jobs:
   publish-npm:
@@ -19,6 +18,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 


### PR DESCRIPTION
Z2JH requires the Docker image from this repo:
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/08faa6f197e478ca28ce23d083287d37096cbb36/jupyterhub/values.yaml#L191

This PR modifies the npm-publish.yml GitHub workflow to also build the Docker image using Docker buildx for `linux/amd64` and `linux/arm64`. The large diff is due to me renaming `npm-publish.yml` to `publish.yml`, the individual commit diffs are clearer. As we've done with other repos I've followed the policy of always running the publish workflow steps for all pushes, with only the actual push/publish step guarded by the tag conditional.

This requires the following Docker Hub secrets:
- [x] `{{ secrets.DOCKERHUB_USERNAME }}`
- [x] `{{ secrets.DOCKERHUB_TOKEN }}`

I presume the image is currently built using a Docker Hub automated build, so that will need to be disabled before this is merged (EDIT: done). An additional advantage of doing the build/push in a GitHub workflow instead of with the automated Docker Hub build is that we can easily push to other registries in future.

This uses a new action [`manics/action-major-minor-tag-calculator`](https://github.com/manics/action-major-minor-tag-calculator) (currently in an intermediate GitHub org for various boring reasons but it could probably move to JupyterHub if there's agreement :smile:) to generate the tags needed for the Docker image from the GitHub tag. E.g. `1.2.3` is expanded to Docker tags `[1.2.3, 1.2, 1, latest]` unless this is a backported tag in which case the newer tags aren't updated.