### PR TITLE
ci: github actions security

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,24 +28,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Setup docker to build for multiple platforms (requires qemu).
-      # See:
-      # https://github.com/docker/build-push-action/tree/v2.3.0#usage
-      # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
+      # Setup docker to build for multiple platforms, see:
+      # https://github.com/docker/build-push-action/tree/v2.4.0#usage
+      # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018 # associated tag: v1.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx (for multi-arch builds)
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609 # associated tag: v1.1.2
 
-      # https://github.com/docker/login-action/tree/v1.8.0#docker-hub
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: Setup push rights to Docker Hub
+        # This was setup by...
+        # 1. Creating a Docker Hub service account "jupyterhubbot"
+        # 2. Creating a access token for the service account specific to this
+        #    repository: https://hub.docker.com/settings/security
+        # 3. Making the account part of the "bots" team, and granting that team
+        #    permissions to push to the relevant images:
+        #    https://hub.docker.com/orgs/jupyterhub/teams/bots/permissions
+        # 4. Registering the username and token as a secret for this repo:
+        #    https://github.com/jupyterhub/configurable-http-proxy/settings/secrets/actions
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
 
       # https://github.com/jupyterhub/action-major-minor-tag-calculator
       # If this is a tagged build this will return additional parent tags.
@@ -56,8 +61,7 @@ jobs:
       # If GITHUB_TOKEN isn't available (e.g. in PRs) returns no tags [].
       - name: Get list of tags
         id: gettags
-        # TODO: Move to org?
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: jupyterhub/action-major-minor-tag-calculator@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "jupyterhub/configurable-http-proxy:"
@@ -66,7 +70,7 @@ jobs:
         run: echo "Docker tags ${{ steps.gettags.outputs.tags }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f # associated tag: v2.4.0
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Removed use of a docker/login-action in favor of a one-liner script doing it, and pinned various github actions in the publish workflow were we reference githu secrets.
