### PR TITLE
Set client SSL on only CA case

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -230,7 +230,7 @@ if (args.apiSslKey || args.apiSslCert) {
   options.apiSsl.rejectUnauthorized = args.apiSslRejectUnauthorized;
 }
 
-if (args.clientSslKey || args.clientSslCert) {
+if (args.clientSslKey || args.clientSslCert || args.clientSslCa) {
   options.clientSsl = {};
   if (args.clientSslKey) {
     options.clientSsl.key = fs.readFileSync(args.clientSslKey);


### PR DESCRIPTION
I'd like to add routes to a server with self-signed TLS without client certification. I think it should be a reasonable use case with a networkpolicy in a Kubernetes cluster.