### PR TITLE
Require node 12+ explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,9 @@ jobs:
     strategy:
       fail-fast: false # Do not cancel all jobs if one fails
       matrix:
+        # IMPORTANT: Make sure to update package.json's enginges.node field to
+        #            always require at least the oldest version.
         node_version:
-          - "10"
           - "12"
           - "14"
           - "15"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ws": "^7.0.0"
   },
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 12.0"
   },
   "engineStrict": true,
   "main": "index.js",


### PR DESCRIPTION
We have failed to require a version of node which we test, which have resulted in failures for those with older versions of node. See for example #321 where node 8 caused problems. I suggest we transition properly to require node 12 at this point which is the oldest version of node with Long Term Support that is actively maintained still.

I figure we could cut a 5.0.0 release with this. In a way it is a bugfix to require node 10 as of 4.4.0 which broke with node 8, and it is a breaking change to require node 12 as node 10 have actually been functional I think. Note though that node 10 have had intermittent test failures while the other versions hasn't.

Since we have flaky tests for node 10, and I don't think our time is merited to debug and support that in detail any more, I suggest we go for node 12 and release CHP 5.0.0.

closes #322