### PR TITLE
Handle store backend errors

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -532,76 +532,77 @@ class ConfigurableProxy extends EventEmitter {
     var args = Array.prototype.slice.call(arguments, 1);
 
     // get the proxy target
-    return this.targetForReq(req).then((match) => {
-      if (!match) {
-        that.handleProxyError(404, kind, req, res);
-        return;
-      }
+    return this.targetForReq(req)
+      .then((match) => {
+        if (!match) {
+          that.handleProxyError(404, kind, req, res);
+          return;
+        }
 
-      if (kind === "web") {
-        that.emit("proxyRequest", req, res);
-      } else {
-        that.emit("proxyRequestWs", req, res, args[2]);
-      }
-      var prefix = match.prefix;
-      var target = match.target;
-      that.log.debug("PROXY %s %s to %s", kind.toUpperCase(), _logUrl(req.url), target);
-      if (!that.includePrefix) {
-        req.url = req.url.slice(prefix.length);
-      }
+        if (kind === "web") {
+          that.emit("proxyRequest", req, res);
+        } else {
+          that.emit("proxyRequestWs", req, res, args[2]);
+        }
+        var prefix = match.prefix;
+        var target = match.target;
+        that.log.debug("PROXY %s %s to %s", kind.toUpperCase(), _logUrl(req.url), target);
+        if (!that.includePrefix) {
+          req.url = req.url.slice(prefix.length);
+        }
 
-      target = URL.parse(target);
-      if (that.options.clientSsl) {
-        target.key = that.options.clientSsl.key;
-        target.cert = that.options.clientSsl.cert;
-        target.ca = that.options.clientSsl.ca;
-      }
+        target = URL.parse(target);
+        if (that.options.clientSsl) {
+          target.key = that.options.clientSsl.key;
+          target.cert = that.options.clientSsl.cert;
+          target.ca = that.options.clientSsl.ca;
+        }
 
-      // add config argument
-      args.push({ target: target });
+        // add config argument
+        args.push({ target: target });
 
-      // add error handling
-      args.push(function (e) {
-        that.handleProxyError(503, kind, req, res, e);
-      });
-
-      // dispatch the actual method, either:
-      // - proxy.web(req, res, options, errorHandler)
-      // - proxy.ws(req, socket, head, options, errorHandler)
-      that.proxy[kind].apply(that.proxy, args);
-
-      // update timestamp on any request/reply data as well (this includes websocket data)
-      req.on("data", function () {
-        that.updateLastActivity(prefix);
-      });
-
-      res.on("data", function () {
-        that.updateLastActivity(prefix);
-      });
-
-      if (kind === "web") {
-        // update last activity on completion of the request
-        // only consider 'successful' requests activity
-        // A flood of invalid requests such as 404s or 403s
-        // or 503s because the endpoint is down
-        // shouldn't make it look like the endpoint is 'active'
-
-        // we no longer register activity at the *start* of the request
-        // because at that point we don't know if the endpoint is even available
-        res.on("finish", function () {
-          // (don't count redirects...but should we?)
-          if (res.statusCode < 300) {
-            that.updateLastActivity(prefix);
-          } else {
-            that.log.debug("Not recording activity for status %s on %s", res.statusCode, prefix);
-          }
+        // add error handling
+        args.push(function (e) {
+          that.handleProxyError(503, kind, req, res, e);
         });
-      }
-    })
-    .catch(function (e) {
-      if (res.finished) throw e;
-      that.handleProxyError(500, kind, req, res, e);
-    });
+
+        // dispatch the actual method, either:
+        // - proxy.web(req, res, options, errorHandler)
+        // - proxy.ws(req, socket, head, options, errorHandler)
+        that.proxy[kind].apply(that.proxy, args);
+
+        // update timestamp on any request/reply data as well (this includes websocket data)
+        req.on("data", function () {
+          that.updateLastActivity(prefix);
+        });
+
+        res.on("data", function () {
+          that.updateLastActivity(prefix);
+        });
+
+        if (kind === "web") {
+          // update last activity on completion of the request
+          // only consider 'successful' requests activity
+          // A flood of invalid requests such as 404s or 403s
+          // or 503s because the endpoint is down
+          // shouldn't make it look like the endpoint is 'active'
+
+          // we no longer register activity at the *start* of the request
+          // because at that point we don't know if the endpoint is even available
+          res.on("finish", function () {
+            // (don't count redirects...but should we?)
+            if (res.statusCode < 300) {
+              that.updateLastActivity(prefix);
+            } else {
+              that.log.debug("Not recording activity for status %s on %s", res.statusCode, prefix);
+            }
+          });
+        }
+      })
+      .catch(function (e) {
+        if (res.finished) throw e;
+        that.handleProxyError(500, kind, req, res, e);
+      });
   }
 
   handleProxyWs(req, socket, head) {

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -379,19 +379,23 @@ class ConfigurableProxy extends EventEmitter {
   }
 
   targetForReq(req) {
-    var metricsTimerEnd = this.metrics.findTargetForReqSummary.startTimer();
-    // return proxy target for a given url path
-    var basePath = this.hostRouting ? "/" + parseHost(req) : "";
-    var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
+    return new Promise((resolve, reject) => {
+      var metricsTimerEnd = this.metrics.findTargetForReqSummary.startTimer();
+      // return proxy target for a given url path
+      var basePath = this.hostRouting ? "/" + parseHost(req) : "";
+      var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
 
-    return this._routes.getTarget(path).then(function (route) {
-      metricsTimerEnd();
-      if (route) {
-        return {
-          prefix: route.prefix,
-          target: route.data.target,
-        };
-      }
+      resolve(
+        this._routes.getTarget(path).then(function (route) {
+          metricsTimerEnd();
+          if (route) {
+            return {
+              prefix: route.prefix,
+              target: route.data.target,
+            };
+          }
+        })
+      ).catch((e) => reject(e));
     });
   }
 
@@ -593,6 +597,10 @@ class ConfigurableProxy extends EventEmitter {
           }
         });
       }
+    })
+    .catch(function (e) {
+      if (res.finished) throw e;
+      that.handleProxyError(500, kind, req, res, e);
     });
   }
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -378,25 +378,19 @@ class ConfigurableProxy extends EventEmitter {
     });
   }
 
-  targetForReq(req) {
-    return new Promise((resolve, reject) => {
-      var metricsTimerEnd = this.metrics.findTargetForReqSummary.startTimer();
-      // return proxy target for a given url path
-      var basePath = this.hostRouting ? "/" + parseHost(req) : "";
-      var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
-
-      resolve(
-        this._routes.getTarget(path).then(function (route) {
-          metricsTimerEnd();
-          if (route) {
-            return {
-              prefix: route.prefix,
-              target: route.data.target,
-            };
-          }
-        })
-      );
-    });
+  async targetForReq(req) {
+    var metricsTimerEnd = this.metrics.findTargetForReqSummary.startTimer();
+    // return proxy target for a given url path
+    var basePath = this.hostRouting ? "/" + parseHost(req) : "";
+    var path = basePath + decodeURIComponent(URL.parse(req.url).pathname);
+    var route = await this._routes.getTarget(path);
+    metricsTimerEnd();
+    if (route) {
+      return {
+        prefix: route.prefix,
+        target: route.data.target,
+      };
+    }
   }
 
   updateLastActivity(prefix) {

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -395,7 +395,7 @@ class ConfigurableProxy extends EventEmitter {
             };
           }
         })
-      ).catch((e) => reject(e));
+      );
     });
   }
 

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -379,6 +379,20 @@ describe("Proxy Tests", function () {
       .then(done);
   });
 
+  it("backend error", function (done) {
+    var proxyPort = 55550;
+    util
+      .setupProxy(proxyPort, { errorTarget: "http://127.0.0.1:55565" }, [])
+      .then(() => r("http://127.0.0.1:" + proxyPort + "/%"))
+      .then((body) => done.fail("Expected 500"))
+      .catch((err) => {
+        expect(err.statusCode).toEqual(500);
+        expect(err.response.headers["content-type"]).toEqual("text/plain");
+        expect(err.response.body).toEqual("/%");
+      })
+      .then(done);
+  });
+
   it("Redirect location untouched without rewrite options", function (done) {
     var redirectTo = "http://foo.com:12345/whatever";
     util


### PR DESCRIPTION
I got the following error with https://github.com/globocom/configurable-http-proxy-redis-backend when I hit a URL like `http://chp.example.com/%25`. Furthermore, the client didn't get a response forever.

```
06:52:05.473 [ConfigProxy] error: Error in handler for GET /%25: URIError: URI malformed
    at decodeURI (<anonymous>)
    at module.exports (/usr/local/lib/node_modules/configurable-http-proxy-redis-backend/node_modules/normalize-url/index.js:87:21)
    at ConfigurableProxyRedisStorage.cleanPath (/usr/local/lib/node_modules/configurable-http-proxy-redis-backend/lib/index.js:109:39)
    at ConfigurableProxyRedisStorage.getTarget (/usr/local/lib/node_modules/configurable-http-proxy-redis-backend/lib/index.js:189:42)
    at ConfigurableProxy.targetForReq (/usr/local/lib/node_modules/configurable-http-proxy/lib/configproxy.js:387:25)
    at ConfigurableProxy.handleProxy (/usr/local/lib/node_modules/configurable-http-proxy/lib/configproxy.js:531:17)
    at ConfigurableProxy.handleProxyWeb (/usr/local/lib/node_modules/configurable-http-proxy/lib/configproxy.js:610:17)
    at Server.<anonymous> (/usr/local/lib/node_modules/configurable-http-proxy/lib/configproxy.js:198:27)
    at Server.emit (events.js:376:20)
    at parserOnIncoming (_http_server.js:896:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:126:17)
```

Although this error should be taken care of by the store backend, CHP should make a response at least.