### PR TITLE
ci: fix details in workflows causing duplicated builds and a failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,12 @@ name: Release
 
 on:
   push:
+    branches-ignore:
+      # don't double-build dependabot PRs
+      - dependabot/**
+    tags:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   # Run tests using node, publish a package when tagged

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
     branches-ignore:
       # don't double-build dependabot PRs
       - dependabot/**
+    tags: ["**"]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
When dependabot triggered a build, the publish-docker job in the publish workflow would fail because...

```
error: invalid tag "jupyterhub/configurable-http-proxy:dependabot/npm_and_yarn/jshint-2.13.0": invalid reference format
Error: buildx call failed with: error: invalid tag "jupyterhub/configurable-http-proxy:dependabot/npm_and_yarn/jshint-2.13.0": invalid reference format
```

With this PR, we disable `push` triggered tests to trigger when dependabot pushes a `dependabot/` prefixed branch, but we still trigger the `pull_request` triggered tests and such that works well still.