### PR TITLE
Fix to flags configuring ip addresses for ipv4+ipv6 compatebility

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -317,9 +317,9 @@ if (args.ip === "*") {
   args.ip = "";
 }
 listen.ip = args.ip;
-listen.apiIp = args.apiIp || "localhost";
+listen.apiIp = args.apiIp;
 listen.apiPort = args.apiPort || listen.port + 1;
-listen.metricsIp = args.metricsIp || "0.0.0.0";
+listen.metricsIp = args.metricsIp;
 listen.metricsPort = args.metricsPort;
 
 proxy.proxyServer.listen(listen.port, listen.ip);

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -87,7 +87,7 @@ cli
   )
   .option("--insecure", "Disable SSL cert verification")
   .option("--host-routing", "Use host routing (host as first level of path)")
-  .option("--metrics-ip <ip>", "IP for metrics server", "0.0.0.0")
+  .option("--metrics-ip <ip>", "IP for metrics server", "")
   .option("--metrics-port <n>", "Port of metrics server. Defaults to no metrics server")
   .option("--log-level <loglevel>", "Log level (debug, info, warn, error)", "info")
   .option(


### PR DESCRIPTION
Small changes to help z2jh avoid IPv4 and/or IPv6 issues by not specifying either `::` or `0.0.0.0` but instead a blank string when we want to listen far and wide as we do in a z2jh container.

### Review notes

I'd love to have this merged soon and cut a release of CHP to bump if for z2jh 1.1.0 that I'd like to make next week.

### Related
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2254
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2318