### PR TITLE
docs: update outdated requirement of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ functionality to [JupyterHub] deployments.
 
 ## Install
 
-Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 6
+Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 12
 
 If you're installing `configurable-http-proxy` in Linux, you can follow [the instruction of nodesource](https://github.com/nodesource/distributions#installation-instructions) to install arbitrary version of Node.js.
 


### PR DESCRIPTION
Thanks @kgutwin for reporting this in https://github.com/jupyterhub/configurable-http-proxy/pull/323#issuecomment-879876679!