### PR TITLE
fix custom-header

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -111,7 +111,7 @@ function collectHeadersIntoObject(value, previous) {
   value = value.trim();
   var colon = value.indexOf(":");
   if (colon <= 0) {
-    log.error("A colon was expected in custom header: " + value);
+    console.error("A colon was expected in custom header: " + value);
     process.exit(1);
   }
   var headerName = value.slice(0, colon).trim();

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -108,12 +108,17 @@ cli
 // collects multiple flags to an object
 // --custom-header "k1:v1" --custom-header " k2 : v2 " --> {"k1":"v1","k2":"v2"}
 function collectHeadersIntoObject(value, previous) {
-  var headerParts = value.split(":").map((p) => p.trim());
-  if (headerParts.length != 2) {
-    log.error("A single colon was expected in custom header: " + value);
+  value = value.trim();
+  var colon = value.indexOf(":");
+  if (colon <= 0) {
+    log.error("A colon was expected in custom header: " + value);
     process.exit(1);
   }
-  previous[headerParts[0]] = headerParts[1];
+  var headerName = value.slice(0, colon).trim();
+  var headerValue = value.slice(colon + 1).trim();
+
+  previous[headerName] = headerValue;
+  return previous;
 }
 
 cli.parse(process.argv);

--- a/test/cli_spec.js
+++ b/test/cli_spec.js
@@ -16,6 +16,17 @@ function executeCLI(execCmd = "bin/configurable-http-proxy", args = []) {
   //cliProcess.stdout.pipe(process.stdout);
   const cliReady = new Promise((resolve, reject) => {
     var promiseResolved = false;
+    cliProcess.stderr.on("data", (data) => {
+      console.log(data.toString());
+    });
+    cliProcess.on("exit", (code) => {
+      if (!promiseResolved) {
+        console.log(
+          "process configurable-http-proxy " + args.join(" ") + "exited with code: " + code
+        );
+        reject();
+      }
+    });
     cliProcess.stdout.on("data", (data) => {
       if (data.includes("Route added /")) {
         defaultRouteAdded = true;
@@ -229,7 +240,7 @@ describe("CLI Tests", function () {
       "--custom-header",
       "k1: v1",
       "--custom-header",
-      " k2 : v2 v2 ",
+      " k2 : host:123 ",
     ];
     executeCLI(execCmd, args).then((cliProcess) => {
       childProcess = cliProcess;
@@ -238,7 +249,7 @@ describe("CLI Tests", function () {
         expect(body.headers).toEqual(
           jasmine.objectContaining({
             k1: "v1",
-            k2: "v2 v2",
+            k2: "host:123",
           })
         );
         done();


### PR DESCRIPTION
collector must return the result

The test was passing because the update-in-place way we implemented the collector apparently works if you have _more than one_ header, but not if you have only one. I don't know if that's a bug upstream or not, but the right thing to do is to return after each collection.

Additional improvements:

- allow colons in header values (split only on first, since colons are quite sensible in header values, e.g. host:port)
- log and exit when proxy cli fails to start in tests


closes #368 