### PR TITLE
Updated alpine base image to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.15
+FROM node:lts-alpine3.16
 # ref: https://hub.docker.com/_/node?tab=tags&name=lts-alpine
 
 LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"


### PR DESCRIPTION
The Alpine 3.15 image has security vulnerabilities according to the XRAY scanning tool. This PR updates the base image to 3.16 so that projects that depend on the configurable http proxy contain all the latest security updates. 