### PR TITLE
ci: small updates to workflows, updating misc versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
   # https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
   publish-npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,19 +42,19 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 
   publish-docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
       # Setup docker to build for multiple platforms, see:
-      # https://github.com/docker/build-push-action/tree/v2.4.0#usage
-      # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
+      # https://github.com/docker/build-push-action/tree/HEAD#usage
+      # https://github.com/docker/build-push-action/blob/HEAD/docs/advanced/multi-platform.md
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # associated tag: v1.0.2
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx (for multi-arch builds)
-        uses: docker/setup-buildx-action@95cb08cb2672c73d4ffd2f422e6d11953d2a9c70 # associated tag: v1.1.2
+        uses: docker/setup-buildx-action@v2
 
       - name: Setup push rights to Docker Hub
         # This was setup by...
@@ -89,7 +89,7 @@ jobs:
         run: echo "Docker tags ${{ steps.gettags.outputs.tags }}"
 
       - name: Build and push
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # associated tag: v2.4.0
+        uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "16"
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   # Audit dependencies for known vulnerabilities
   audit-dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,8 @@ jobs:
           - "12"
           - "14"
           - "16"
-          - "17"
+          - "18"
+          - "19"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- ci: use ubuntu-22.04 runners
- ci: use node 16 in runners
- ci: update to use vX versions of docker actions
- ci: stop tests against node 17, test against node 18 and 19

Closes #438
