### PR TITLE
Update base image to node:lts-alpine3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.16
+FROM node:lts-alpine3.17
 # ref: https://hub.docker.com/_/node?tab=tags&name=lts-alpine
 
 # Set labels based on the Open Containers Initiative (OCI):


### PR DESCRIPTION
`node:lts-alpine3.16` has security vulnerabilities which are fixed in `node:lts-alpine3.17`.

Scanned with JFrog X-RAY extension for Docker Desktop.
- node:lts-alpine3.16
![image](https://user-images.githubusercontent.com/57374665/228764426-900d1400-f44c-439c-a415-f1b7493e18dd.png)
- node:lts-alpine3.17
![image](https://user-images.githubusercontent.com/57374665/228764595-3a7a1a05-355f-4fd3-9cd6-3d451034cece.png)