### PR TITLE
test: enable keepAlive on proxy web server

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -219,12 +219,15 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
-    var proxyOptions = {keepAlive: true};
+    var proxyOptions = { keepAlive: true };
 
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);
     if (this.options.ssl) {
-      this.proxyServer = https.createServer({...this.options.ssl, ...proxyOptions}, proxyCallback);
+      this.proxyServer = https.createServer(
+        { ...this.options.ssl, ...proxyOptions },
+        proxyCallback
+      );
     } else {
       this.proxyServer = http.createServer(proxyOptions, proxyCallback);
     }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -219,12 +219,14 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
+    var proxyOptions = {keepAlive: true};
+
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);
     if (this.options.ssl) {
-      this.proxyServer = https.createServer(this.options.ssl, proxyCallback);
+      this.proxyServer = https.createServer({...this.options.ssl, ...proxyOptions}, proxyCallback);
     } else {
-      this.proxyServer = http.createServer(proxyCallback);
+      this.proxyServer = http.createServer(proxyOptions, proxyCallback);
     }
     // proxy websockets
     this.proxyServer.on("upgrade", bound(this, this.handleProxyWs));


### PR DESCRIPTION
to see if it improves performance.

Idea from https://github.com/http-party/node-http-proxy/issues/1058
[docs](https://nodejs.org/api/http.html#new-agentoptions)