### PR TITLE
Introduce keep alive and fix AWS Load Balancer 502 errors

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -107,12 +107,12 @@ cli
   ) 
   .option(
     "--server-keep-alive-timeout <n>",
-    "The number of milliseconds of inactivity a server needs to wait for additional incoming data, after it has finished writing the last response, before a socket will be destroyed. Default: 5000",
+    "The number of milliseconds of inactivity a server needs to wait for additional incoming data, after it has finished writing the last response, before a socket will be destroyed.",
     parseInt
   )
   .option(
     "--agent-free-socket-timeout <n>",
-    "Sets the free socket to timeout after freeSocketTimeout milliseconds of inactivity on the free socket. The default server-side timeout is 5000 milliseconds, to avoid ECONNRESET exceptions, we set the default value to 4000 milliseconds. Only relevant if keepAlive is set to true",
+    "Sets the free socket to timeout after freeSocketTimeout milliseconds of inactivity on the free socket.",
     parseInt
   );
 

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -11,7 +11,8 @@ var fs = require("fs"),
   pkg = require("../package.json"),
   cli = require("commander"),
   tls = require("tls"),
-  winston = require("winston");
+  winston = require("winston"),
+  Agent = require("agentkeepalive");
 
 cli
   .version(pkg.version)
@@ -103,6 +104,16 @@ cli
   .option(
     "--storage-backend <storage-class>",
     "Define an external storage class. Defaults to in-MemoryStore."
+  ) 
+  .option(
+    "--server-keep-alive-timeout <n>",
+    "The number of milliseconds of inactivity a server needs to wait for additional incoming data, after it has finished writing the last response, before a socket will be destroyed. Default: 5000",
+    parseInt
+  )
+  .option(
+    "--agent-free-socket-timeout <n>",
+    "Sets the free socket to timeout after freeSocketTimeout milliseconds of inactivity on the free socket. The default server-side timeout is 5000 milliseconds, to avoid ECONNRESET exceptions, we set the default value to 4000 milliseconds. Only relevant if keepAlive is set to true",
+    parseInt
   );
 
 // collects multiple flags to an object
@@ -310,6 +321,12 @@ if (!options.authToken) {
 // external backend class
 options.storageBackend = args.storageBackend;
 
+if (args.agentFreeSocketTimeout) {
+  options.agent = new Agent({
+    freeSocketTimeout: args.agentFreeSocketTimeout,
+  });
+}
+
 var proxy = new ConfigurableProxy(options);
 
 var listen = {};
@@ -326,6 +343,11 @@ listen.apiIp = args.apiIp;
 listen.apiPort = args.apiPort || listen.port + 1;
 listen.metricsIp = args.metricsIp;
 listen.metricsPort = args.metricsPort;
+
+if (args.serverKeepAliveTimeout) {
+  proxy.proxyServer.keepAliveTimeout = args.serverKeepAliveTimeout;
+  proxy.proxyServer.headersTimeout = args.serverKeepAliveTimeout + 1000;
+}
 
 proxy.proxyServer.listen(listen.port, listen.ip);
 proxy.apiServer.listen(listen.apiPort, listen.apiIp);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.5.7-dev.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "agentkeepalive": "^4.3.0",
         "commander": "~7.2",
         "http-proxy": "^1.18.1",
         "prom-client": "14.2.0",
@@ -349,6 +350,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -1204,6 +1216,14 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -2845,6 +2865,14 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3534,6 +3562,14 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "http-proxy": "^1.18.1",
     "prom-client": "14.2.0",
     "strftime": "~0.10.0",
-    "winston": "~3.10.0"
+    "winston": "~3.10.0",
+    "agentkeepalive": "^4.3.0"
   },
   "devDependencies": {
     "jasmine": "^3.5.0",


### PR DESCRIPTION
I'm running Z2JH based service with about 1,000 DAU. It is deployed in AWS EKS attached to AWS ALB.
![image](https://github.com/jupyterhub/configurable-http-proxy/assets/4434752/1e99129a-10d2-411a-83e9-7c22e5cb36b0)


As DAU grows, users started to get 502 Responses from the LB.
![image](https://github.com/jupyterhub/configurable-http-proxy/assets/4434752/b52a0628-fcb1-4fda-89d9-b02b78404383)

This is well-known problem related to keep-alive setting. ([AWS Article](https://repost.aws/knowledge-center/elb-alb-troubleshoot-502-errors))
Unfortunately, configurable-http-proxy does not support keep-alive. So I implemented, and tested in production environment. 

After the deployment the number of 502 errors descreased.
![image](https://github.com/jupyterhub/configurable-http-proxy/assets/4434752/9411fb7b-21f1-46ec-8beb-0998c03238b9)

Technical/Implementation detail

1) It is very important to allow keep-alive both client side and server side. That's why `Agent` and `keepAliveTimeout` are both needed.

2) The jupyter hub and jupyter server support keep-alive by default, because they are Tornado servers.

3) chp is given these parameters. They are AWS specific values.
```
"--server-keep-alive-timeout=61000"
"--agent-free-socket-timeout=62000"
```
