### PR TITLE
Enable keep-alive, `--keep-alive-timeout` flag added (default: 5000ms)

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -103,6 +103,11 @@ cli
   .option(
     "--storage-backend <storage-class>",
     "Define an external storage class. Defaults to in-MemoryStore."
+  )
+  .option(
+    "--keep-alive-timeout <timeout>",
+    "Set timeout (in milliseconds) for Keep-Alive connections",
+    parseInt
   );
 
 // collects multiple flags to an object
@@ -269,6 +274,7 @@ options.redirectTo = args.redirectTo;
 options.headers = args.customHeader;
 options.timeout = args.timeout;
 options.proxyTimeout = args.proxyTimeout;
+options.keepAliveTimeout = args.keepAliveTimeout;
 
 // metrics options
 options.enableMetrics = !!args.metricsPort;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -220,7 +220,11 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
-    var httpOptions = { keepAlive: true, agent: this.agent };
+    var httpOptions = {
+      keepAlive: true,
+      agent: this.agent,
+      keepAliveTimeout: this.options.keepAliveTimeout || 5000,
+    };
 
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -173,7 +173,6 @@ class ConfigurableProxy extends EventEmitter {
       });
     }
     options.ws = true;
-    this.agent = options.agent = new http.Agent({ keepAlive: true });
     var proxy = (this.proxy = httpProxy.createProxyServer(options));
 
     // tornado-style regex routing,
@@ -220,9 +219,14 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
+    // need separate agents for http and https requests
+    // these agents allow our _upstream_ sockets to be kept alive
+    this.httpAgent = http.globalAgent = new http.Agent({ keepAlive: true });
+    this.httpsAgent = https.globalAgent = new https.Agent({ keepAlive: true });
+
+    // these settings configure requests to the proxy itself to accept keep-alive
     var httpOptions = {
       keepAlive: true,
-      agent: this.agent,
       keepAliveTimeout: this.options.keepAliveTimeout || 5000,
     };
 
@@ -560,7 +564,13 @@ class ConfigurableProxy extends EventEmitter {
         }
 
         // add config argument
-        args.push({ target: target });
+        var proxyOptions = { target: target };
+        if (target.protocol.slice(-2) === "s:") {
+          proxyOptions.agent = that.httpsAgent;
+        } else {
+          proxyOptions.agent = that.httpAgent;
+        }
+        args.push(proxyOptions);
 
         // add error handling
         args.push(function (e) {

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -219,12 +219,15 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
-    var proxyOptions = {keepAlive: true};
+    var proxyOptions = { keepAlive: true };
 
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);
     if (this.options.ssl) {
-      this.proxyServer = https.createServer({...this.options.ssl, ...proxyOptions}, proxyCallback);
+      this.proxyServer = https.createServer(
+        { ...this.options.ssl, ...proxyOptions },
+        proxyCallback
+      );
     } else {
       this.proxyServer = http.createServer(proxyOptions, proxyCallback);
     }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -219,12 +219,14 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
+    var proxyOptions = {keepAlive: true};
+
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);
     if (this.options.ssl) {
-      this.proxyServer = https.createServer(this.options.ssl, proxyCallback);
+      this.proxyServer = https.createServer({...this.options.ssl, ...proxyOptions}, proxyCallback);
     } else {
-      this.proxyServer = http.createServer(proxyCallback);
+      this.proxyServer = http.createServer(proxyOptions, proxyCallback);
     }
     // proxy websockets
     this.proxyServer.on("upgrade", bound(this, this.handleProxyWs));

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -173,6 +173,7 @@ class ConfigurableProxy extends EventEmitter {
       });
     }
     options.ws = true;
+    this.agent = options.agent = new http.Agent({ keepAlive: true });
     var proxy = (this.proxy = httpProxy.createProxyServer(options));
 
     // tornado-style regex routing,
@@ -219,17 +220,14 @@ class ConfigurableProxy extends EventEmitter {
       this.metricsServer = http.createServer(metricsCallback);
     }
 
-    var proxyOptions = { keepAlive: true };
+    var httpOptions = { keepAlive: true, agent: this.agent };
 
     // proxy requests separately
     var proxyCallback = logErrors(this.handleProxyWeb);
     if (this.options.ssl) {
-      this.proxyServer = https.createServer(
-        { ...this.options.ssl, ...proxyOptions },
-        proxyCallback
-      );
+      this.proxyServer = https.createServer({ ...this.options.ssl, ...httpOptions }, proxyCallback);
     } else {
-      this.proxyServer = http.createServer(proxyOptions, proxyCallback);
+      this.proxyServer = http.createServer(httpOptions, proxyCallback);
     }
     // proxy websockets
     this.proxyServer.on("upgrade", bound(this, this.handleProxyWs));

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -1,6 +1,7 @@
 // jshint jasmine: true
 "use strict";
 
+var http = require("http");
 var path = require("path");
 var util = require("../lib/testutil");
 var request = require("request-promise-native");
@@ -83,6 +84,21 @@ describe("Proxy Tests", function () {
     });
     ws.on("open", function () {
       ws.send("hi");
+    });
+  });
+
+  it("keep-alive proxy request", function (done) {
+    var agent = new http.Agent({ keepAlive: true });
+    r(proxyUrl, { agent: agent, resolveWithFullResponse: true }).then((res) => {
+      agent.destroy();
+      var body = JSON.parse(res.body);
+      expect(body).toEqual(
+        jasmine.objectContaining({
+          path: "/",
+        })
+      );
+      expect(res.headers["connection"]).toEqual("keep-alive");
+      done();
     });
   });
 


### PR DESCRIPTION
extends #481 to enable keepAlive not just on the server, but on proxied requests as well via an http agent, and exposing timeout on the command-line.

alternative to #491 using the standard library

closes #481 
closes #491