### PR TITLE
Revert "build(deps): bump prom-client from 14.2.0 to 15.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "commander": "~7.2",
         "http-proxy": "^1.18.1",
-        "prom-client": "15.0.0",
+        "prom-client": "14.2.0",
         "strftime": "~0.10.0",
         "winston": "~3.11.0"
       },
@@ -447,14 +447,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -1955,15 +1947,14 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.0.0.tgz",
-      "integrity": "sha512-UocpgIrKyA2TKLVZDSfm8rGkL13C19YrQBAiG3xo3aDFWcHedxRxI3z+cIcucoxpSO0h5lff5iv/SXoxyeopeA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
       "dependencies": {
-        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": "^16 || ^18 || >=20"
+        "node": ">=10"
       }
     },
     "node_modules/psl": {
@@ -3012,11 +3003,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g=="
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -4216,11 +4202,10 @@
       }
     },
     "prom-client": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.0.0.tgz",
-      "integrity": "sha512-UocpgIrKyA2TKLVZDSfm8rGkL13C19YrQBAiG3xo3aDFWcHedxRxI3z+cIcucoxpSO0h5lff5iv/SXoxyeopeA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
       "requires": {
-        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "commander": "~7.2",
     "http-proxy": "^1.18.1",
-    "prom-client": "15.0.0",
+    "prom-client": "14.2.0",
     "strftime": "~0.10.0",
     "winston": "~3.11.0"
   },


### PR DESCRIPTION
Reverts jupyterhub/configurable-http-proxy#505

Didn't notice it drops node support (it passed our CI tests though)

