### PR TITLE
fix errorTarget with websockets

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -486,6 +486,14 @@ export class ConfigurableProxy extends EventEmitter {
       // socket-level error, no response to build
       return;
     }
+    if (kind === "ws") {
+      if (!res.writableEnded) {
+        // send empty http response with status
+        res.write(`HTTP/${req.httpVersion} ${code}\r\nContent-Length: 0\r\n\r\n`);
+      }
+      // http-proxy-3 calls res.destroySoon() after we return from here
+      return;
+    }
     if (this.errorTarget) {
       var urlSpec = new URL(this.errorTarget);
       // error request is $errorTarget/$code?url=$requestUrl
@@ -497,9 +505,14 @@ export class ConfigurableProxy extends EventEmitter {
       var options = this.proxyOptsForTarget(urlSpec, req.url);
       options.method = "GET";
 
-      var errorRequest = (options.secure ? https : http).request(url, options, function (upstream) {
-        if (res.writableEnded) return; // response already done
-        ["content-type", "content-encoding"].map(function (key) {
+      var errorRequest = (options.secure ? https : http).request(url, options, (upstream) => {
+        if (res.writableEnded) {
+          // response already done
+          // make sure to consume upstream;
+          upstream.resume();
+          return;
+        }
+        ["content-type", "content-encoding"].map((key) => {
           if (!upstream.headers[key]) return;
           if (res.setHeader) res.setHeader(key, upstream.headers[key]);
         });


### PR DESCRIPTION
- don't build standard error responses for websocket errors, just send the error code and empty response. Websockets can't access error responses anyway.
- make sure to resume error request if incoming response is already over, otherwise we'll get leftover sockets (this is why we kept accumulating ESTABLISHED sockets - we never consumed the error request because the incoming response had already been closed by that point, and you need to `resume()` to consume a response if you aren't going to use it.

for more information, see [#557](https://github.com/jupyterhub/configurable-http-proxy/issues/557#issuecomment-3332149780)