### PR TITLE
feat: Allow --error-path fallback when --error-target error fetch fails

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -70,7 +70,10 @@ cli
     "--error-target <host>",
     "Alternate server for handling proxy errors (proto://host[:port])"
   )
-  .option("--error-path <path>", "Alternate server for handling proxy errors (proto://host[:port])")
+  .option(
+    "--error-path <path>",
+    "Directory containing {status}.html (and optional error.html) for proxy errors"
+  )
   .option(
     "--redirect-port <redirect-port>",
     "Redirect HTTP requests on this port to the server on HTTPS"
@@ -293,8 +296,9 @@ if (!options.ssl && options.redirectPort) {
 }
 
 if (options.errorTarget && options.errorPath) {
-  log.error("Cannot specify both error-target and error-path. Pick one.");
-  process.exit(1);
+  log.info(
+    "Both error-target and error-path set: serve from error-target when reachable; otherwise use error-path files."
+  );
 }
 
 // passthrough for http-proxy options

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -75,6 +75,11 @@ cli
     "Directory containing {status}.html (and optional error.html) for proxy errors"
   )
   .option(
+    "--error-target-timeout <n>",
+    "Timeout in ms when fetching pages from --error-target (default 10000)",
+    parseInt
+  )
+  .option(
     "--redirect-port <redirect-port>",
     "Redirect HTTP requests on this port to the server on HTTPS"
   )
@@ -277,6 +282,9 @@ if (args.clientSslKey || args.clientSslCert || args.clientSslCa) {
 options.defaultTarget = args.defaultTarget;
 options.errorTarget = args.errorTarget;
 options.errorPath = args.errorPath;
+if (args.errorTargetTimeout !== undefined) {
+  options.errorTargetTimeout = args.errorTargetTimeout;
+}
 options.hostRouting = args.hostRouting;
 options.authToken = process.env.CONFIGPROXY_AUTH_TOKEN;
 options.redirectPort = args.redirectPort;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -486,6 +486,38 @@ export class ConfigurableProxy extends EventEmitter {
     if (res.end) res.end();
   }
 
+  /**
+   * Serve HTML from errorPath ({code}.html, else error.html).
+   * Used when errorPath is set alone, or as fallback when errorTarget fails.
+   */
+  _handleProxyErrorFromPath(code, kind, req, res) {
+    if (!this.errorPath) {
+      this._handleProxyErrorDefault(code, kind, req, res);
+      return;
+    }
+    var filename = path.join(this.errorPath, code.toString() + ".html");
+    if (!fs.existsSync(filename)) {
+      this.log.debug("No error file %s", filename);
+      filename = path.join(this.errorPath, "error.html");
+      if (!fs.existsSync(filename)) {
+        this.log.error("No error file %s", filename);
+        this._handleProxyErrorDefault(code, kind, req, res);
+        return;
+      }
+    }
+    fs.readFile(filename, (err, data) => {
+      if (err) {
+        this.log.error("Error reading %s %s", filename, err);
+        this._handleProxyErrorDefault(code, kind, req, res);
+        return;
+      }
+      if (!res.writable) return; // response already done
+      if (res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
+      if (res.write) res.write(data);
+      if (res.end) res.end();
+    });
+  }
+
   handleProxyError(code, kind, req, res, e) {
     // called when proxy itself has an error
     // so far, just 404 for no target and 503 for target not responding
@@ -569,33 +601,16 @@ export class ConfigurableProxy extends EventEmitter {
         }
       );
       errorRequest.on("error", (e) => {
-        // custom error failed, fallback on default
         this.log.error("Failed to get custom error page: %s", e);
-        this._handleProxyErrorDefault(code, kind, req, res);
+        if (this.errorPath) {
+          this._handleProxyErrorFromPath(code, kind, req, res);
+        } else {
+          this._handleProxyErrorDefault(code, kind, req, res);
+        }
       });
       errorRequest.end();
     } else if (this.errorPath) {
-      var filename = path.join(this.errorPath, code.toString() + ".html");
-      if (!fs.existsSync(filename)) {
-        this.log.debug("No error file %s", filename);
-        filename = path.join(this.errorPath, "error.html");
-        if (!fs.existsSync(filename)) {
-          this.log.error("No error file %s", filename);
-          this._handleProxyErrorDefault(code, kind, req, res);
-          return;
-        }
-      }
-      fs.readFile(filename, (err, data) => {
-        if (err) {
-          this.log.error("Error reading %s %s", filename, err);
-          this._handleProxyErrorDefault(code, kind, req, res);
-          return;
-        }
-        if (!res.writable) return; // response already done
-        if (res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
-        if (res.write) res.write(data);
-        if (res.end) res.end();
-      });
+      this._handleProxyErrorFromPath(code, kind, req, res);
     } else {
       this._handleProxyErrorDefault(code, kind, req, res);
     }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -197,14 +197,11 @@ export class ConfigurableProxy extends EventEmitter {
     this.errorPath = options.errorPath || path.join(__dirname, "error");
 
     var eto =
-      options.errorTargetTimeout ??
-      options.error_target_timeout ??
-      this.options.errorTargetTimeout;
+      options.errorTargetTimeout ?? options.error_target_timeout ?? this.options.errorTargetTimeout;
     if (eto === undefined || eto === null) {
       eto = 10000;
     }
-    this.errorTargetTimeout =
-      typeof eto === "string" ? parseInt(eto, 10) : Number(eto);
+    this.errorTargetTimeout = typeof eto === "string" ? parseInt(eto, 10) : Number(eto);
     if (!Number.isFinite(this.errorTargetTimeout) || this.errorTargetTimeout < 1) {
       this.errorTargetTimeout = 10000;
     }
@@ -613,29 +610,25 @@ export class ConfigurableProxy extends EventEmitter {
         }
       }
 
-      errorRequest = (options.secure ? https : http).request(
-        url,
-        options.target,
-        (upstream) => {
-          if (res.writableEnded) {
-            // response already done
-            // make sure to consume upstream;
-            upstream.resume();
-            return;
-          }
-          ["content-type", "content-encoding"].map((key) => {
-            if (!upstream.headers[key]) return;
-            if (res.setHeader) res.setHeader(key, upstream.headers[key]);
-          });
-          if (res.writeHead) res.writeHead(code);
-          upstream.on("data", (data) => {
-            if (res.write && !res.writableEnded) res.write(data);
-          });
-          upstream.on("end", () => {
-            if (res.end) res.end();
-          });
+      errorRequest = (options.secure ? https : http).request(url, options.target, (upstream) => {
+        if (res.writableEnded) {
+          // response already done
+          // make sure to consume upstream;
+          upstream.resume();
+          return;
         }
-      );
+        ["content-type", "content-encoding"].map((key) => {
+          if (!upstream.headers[key]) return;
+          if (res.setHeader) res.setHeader(key, upstream.headers[key]);
+        });
+        if (res.writeHead) res.writeHead(code);
+        upstream.on("data", (data) => {
+          if (res.write && !res.writableEnded) res.write(data);
+        });
+        upstream.on("end", () => {
+          if (res.end) res.end();
+        });
+      });
       errorRequest.setTimeout(this.errorTargetTimeout, function () {
         settleErrorTargetFailure(new Error("error-target timeout"));
       });

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -511,8 +511,9 @@ export class ConfigurableProxy extends EventEmitter {
         this._handleProxyErrorDefault(code, kind, req, res);
         return;
       }
-      if (!res.writable) return; // response already done
-      if (res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
+      if (res.writableEnded) return; // response already done
+      if (!res.headersSent && res.writeHead)
+        res.writeHead(code, { "Content-Type": "text/html" });
       if (res.write) res.write(data);
       if (res.end) res.end();
     });

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -512,8 +512,7 @@ export class ConfigurableProxy extends EventEmitter {
         return;
       }
       if (res.writableEnded) return; // response already done
-      if (!res.headersSent && res.writeHead)
-        res.writeHead(code, { "Content-Type": "text/html" });
+      if (!res.headersSent && res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
       if (res.write) res.write(data);
       if (res.end) res.end();
     });

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -196,6 +196,19 @@ export class ConfigurableProxy extends EventEmitter {
     }
     this.errorPath = options.errorPath || path.join(__dirname, "error");
 
+    var eto =
+      options.errorTargetTimeout ??
+      options.error_target_timeout ??
+      this.options.errorTargetTimeout;
+    if (eto === undefined || eto === null) {
+      eto = 10000;
+    }
+    this.errorTargetTimeout =
+      typeof eto === "string" ? parseInt(eto, 10) : Number(eto);
+    if (!Number.isFinite(this.errorTargetTimeout) || this.errorTargetTimeout < 1) {
+      this.errorTargetTimeout = 10000;
+    }
+
     if (this.options.enableMetrics) {
       this.metrics = new metrics.Metrics();
     } else {
@@ -577,7 +590,30 @@ export class ConfigurableProxy extends EventEmitter {
 
       this.log.debug("Requesting custom error page: %s", url);
 
-      var errorRequest = (options.secure ? https : http).request(
+      var that = this;
+      var settled = false;
+      var errorRequest;
+      function settleErrorTargetFailure(err) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (errorRequest) {
+          errorRequest.destroy();
+        }
+        var msg =
+          err && err.message === "error-target timeout"
+            ? err.message + " (" + that.errorTargetTimeout + "ms)"
+            : err;
+        that.log.error("Failed to get custom error page: %s", msg);
+        if (that.errorPath) {
+          that._handleProxyErrorFromPath(code, kind, req, res);
+        } else {
+          that._handleProxyErrorDefault(code, kind, req, res);
+        }
+      }
+
+      errorRequest = (options.secure ? https : http).request(
         url,
         options.target,
         (upstream) => {
@@ -600,14 +636,10 @@ export class ConfigurableProxy extends EventEmitter {
           });
         }
       );
-      errorRequest.on("error", (e) => {
-        this.log.error("Failed to get custom error page: %s", e);
-        if (this.errorPath) {
-          this._handleProxyErrorFromPath(code, kind, req, res);
-        } else {
-          this._handleProxyErrorDefault(code, kind, req, res);
-        }
+      errorRequest.setTimeout(this.errorTargetTimeout, function () {
+        settleErrorTargetFailure(new Error("error-target timeout"));
       });
+      errorRequest.on("error", settleErrorTargetFailure);
       errorRequest.end();
     } else if (this.errorPath) {
       this._handleProxyErrorFromPath(code, kind, req, res);

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,7 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -205,7 +205,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -545,7 +545,7 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,11 +187,34 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/c8": {
       "version": "11.0.0",
@@ -521,9 +544,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://artifactory.g.devqa.gcp.dev.paypalinc.com/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -817,29 +840,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -388,6 +388,39 @@ describe("Proxy Tests", function () {
       .then(done);
   });
 
+  it("error-target times out and falls back to error-path", function (done) {
+    const hang = http.createServer(() => {});
+    hang.listen(0, "127.0.0.1", () => {
+      const port = hang.address().port;
+      proxy.errorTarget = "http://127.0.0.1:" + port + "/";
+      proxy.errorPath = path.join(__dirname, "error");
+      proxy.errorTargetTimeout = 250;
+      proxy
+        .removeRoute("/")
+        .then(() => proxy.addRoute("/missing", { target: "https://127.0.0.1:54321" }))
+        .then(() => fetch(hostUrl + "/missing/prefix"))
+        .then((res) => {
+          expect(res.status).toEqual(503);
+          expect(res.headers.get("content-type")).toEqual("text/html");
+          return res.text();
+        })
+        .then((body) => {
+          expect(body).toMatch(/UNKNOWN/);
+        })
+        .then(
+          () =>
+            new Promise((resolve, reject) => {
+              hang.close((err) => (err ? reject(err) : resolve()));
+            })
+        )
+        .then(done)
+        .catch((e) => {
+          hang.close();
+          done.fail(e);
+        });
+    });
+  });
+
   it("custom error path", function (done) {
     proxy.errorPath = path.join(__dirname, "error");
     proxy

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -361,6 +361,33 @@ describe("Proxy Tests", function () {
       .then(done);
   });
 
+  it("error-target fetch fails and falls back to error-path files", function (done) {
+    proxy.errorTarget = "http://127.0.0.1:55599/";
+    proxy.errorPath = path.join(__dirname, "error");
+    proxy
+      .removeRoute("/")
+      .then(() => proxy.addRoute("/missing", { target: "https://127.0.0.1:54321" }))
+      .then(() => fetch(hostUrl + "/nope"))
+      .then((res) => {
+        expect(res.status).toEqual(404);
+        expect(res.headers.get("content-type")).toEqual("text/html");
+        return res.text();
+      })
+      .then((body) => {
+        expect(body).toMatch(/404/);
+      })
+      .then(() => fetch(hostUrl + "/missing/prefix"))
+      .then((res) => {
+        expect(res.status).toEqual(503);
+        expect(res.headers.get("content-type")).toEqual("text/html");
+        return res.text();
+      })
+      .then((body) => {
+        expect(body).toMatch(/UNKNOWN/);
+      })
+      .then(done);
+  });
+
   it("custom error path", function (done) {
     proxy.errorPath = path.join(__dirname, "error");
     proxy


### PR DESCRIPTION
**Problem:**

Today you must choose either --error-target or --error-path. If --error-target is set and the request to the custom error server fails (hub down, connection refused, etc.), CHP only returns the generic plain-text response. Static HTML under --error-path is never used in that case.

**Change:**

- Permit both --error-target and --error-path. When --error-target is configured, CHP still tries the custom error URL first. On request error, serve HTML from --error-path using the existing rules ({code}.html, then error.html, else default).

-  Fix --error-path CLI help: it is a directory of HTML files, not another proto://host server.

Add a test that uses an unreachable errorTarget and asserts responses come from the error-path fixtures.

**Backward compatibility:**
Using only --error-target or only --error-path behaves as before. If both are set, behavior is: dynamic page when reachable; otherwise file-based fallback.