### PR TITLE
feat: timeout error-target fetch and fall back to error-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ functionality to [JupyterHub] deployments.
 - [Custom error pages](#custom-error-pages)
   - [Setting the path for custom error pages](#setting-the-path-for-custom-error-pages)
   - [Setting a target for custom error handling](#setting-a-target-for-custom-error-handling)
+  - [Combining error-target with error-path fallback](#combining-error-target-with-error-path-fallback)
 - [Host-based routing](#host-based-routing)
 - [Troubleshooting](#troubleshooting)
 
@@ -136,7 +137,8 @@ Options:
   --client-ssl-reject-unauthorized   Reject unauthorized SSL connections (only meaningful if --client-ssl-request-cert is given)
   --default-target <host>            Default proxy target (proto://host[:port])
   --error-target <host>              Alternate server for handling proxy errors (proto://host[:port])
-  --error-path <path>                Alternate server for handling proxy errors (proto://host[:port])
+  --error-target-timeout <n>         Timeout in ms when fetching pages from --error-target (default 10000)
+  --error-path <path>                Directory containing {status}.html (and optional error.html) for proxy errors
   --redirect-port <redirect-port>    Redirect HTTP requests on this port to the server on HTTPS
   --redirect-to <port>               Redirect HTTP requests from --redirect-port to this port
   --pid-file <pid-file>              Write our PID to a file
@@ -339,6 +341,39 @@ server URL, `http://localhost:1234`, appending the status code
 `/{CODE}`, and passing the failing request's URL escaped in a URL parameter:
 
     GET /404?url=%2Fescaped%2Fpath
+
+By default, CHP will wait up to **10 seconds** for the `error-target` server
+to respond. You can change this with `--error-target-timeout`:
+
+```bash
+configurable-http-proxy --error-target http://localhost:1234 --error-target-timeout 5000
+```
+
+[**Return to top**][]
+
+### Combining error-target with error-path fallback
+
+You can set both `--error-target` and `--error-path` together. In this mode,
+CHP will **first try** the `error-target` server. If that request fails (e.g.
+the server is down, unreachable, or does not respond within
+`--error-target-timeout` ms), CHP will **fall back** to serving static error
+pages from `--error-path`.
+
+```bash
+configurable-http-proxy \
+  --error-target http://localhost:1234 \
+  --error-target-timeout 5000 \
+  --error-path /usr/share/chp-errors
+```
+
+This makes your error handling resilient: users still get a meaningful error
+page even when the dedicated error-handling service is unavailable.
+
+**Fallback priority:**
+
+1. `--error-target` — preferred; fetched with the configured timeout
+2. `--error-path` — used when `error-target` is unreachable or times out
+3. Built-in default error response — used when neither is configured or available
 
 [**Return to top**][]
 

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -70,7 +70,15 @@ cli
     "--error-target <host>",
     "Alternate server for handling proxy errors (proto://host[:port])"
   )
-  .option("--error-path <path>", "Alternate server for handling proxy errors (proto://host[:port])")
+  .option(
+    "--error-path <path>",
+    "Directory containing {status}.html (and optional error.html) for proxy errors"
+  )
+  .option(
+    "--error-target-timeout <n>",
+    "Timeout in ms when fetching pages from --error-target (default 10000)",
+    parseInt
+  )
   .option(
     "--redirect-port <redirect-port>",
     "Redirect HTTP requests on this port to the server on HTTPS"
@@ -274,6 +282,9 @@ if (args.clientSslKey || args.clientSslCert || args.clientSslCa) {
 options.defaultTarget = args.defaultTarget;
 options.errorTarget = args.errorTarget;
 options.errorPath = args.errorPath;
+if (args.errorTargetTimeout !== undefined) {
+  options.errorTargetTimeout = args.errorTargetTimeout;
+}
 options.hostRouting = args.hostRouting;
 options.authToken = process.env.CONFIGPROXY_AUTH_TOKEN;
 options.redirectPort = args.redirectPort;
@@ -293,8 +304,9 @@ if (!options.ssl && options.redirectPort) {
 }
 
 if (options.errorTarget && options.errorPath) {
-  log.error("Cannot specify both error-target and error-path. Pick one.");
-  process.exit(1);
+  log.info(
+    "Both error-target and error-path set: serve from error-target when reachable; otherwise use error-path files."
+  );
 }
 
 // passthrough for http-proxy options

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -196,6 +196,16 @@ export class ConfigurableProxy extends EventEmitter {
     }
     this.errorPath = options.errorPath || path.join(__dirname, "error");
 
+    var eto =
+      options.errorTargetTimeout ?? options.error_target_timeout ?? this.options.errorTargetTimeout;
+    if (eto === undefined || eto === null) {
+      eto = 10000;
+    }
+    this.errorTargetTimeout = typeof eto === "string" ? parseInt(eto, 10) : Number(eto);
+    if (!Number.isFinite(this.errorTargetTimeout) || this.errorTargetTimeout < 1) {
+      this.errorTargetTimeout = 10000;
+    }
+
     if (this.options.enableMetrics) {
       this.metrics = new metrics.Metrics();
     } else {
@@ -486,6 +496,38 @@ export class ConfigurableProxy extends EventEmitter {
     if (res.end) res.end();
   }
 
+  /**
+   * Serve HTML from errorPath ({code}.html, else error.html).
+   * Used when errorPath is set alone, or as fallback when errorTarget fails.
+   */
+  _handleProxyErrorFromPath(code, kind, req, res) {
+    if (!this.errorPath) {
+      this._handleProxyErrorDefault(code, kind, req, res);
+      return;
+    }
+    var filename = path.join(this.errorPath, code.toString() + ".html");
+    if (!fs.existsSync(filename)) {
+      this.log.debug("No error file %s", filename);
+      filename = path.join(this.errorPath, "error.html");
+      if (!fs.existsSync(filename)) {
+        this.log.error("No error file %s", filename);
+        this._handleProxyErrorDefault(code, kind, req, res);
+        return;
+      }
+    }
+    fs.readFile(filename, (err, data) => {
+      if (err) {
+        this.log.error("Error reading %s %s", filename, err);
+        this._handleProxyErrorDefault(code, kind, req, res);
+        return;
+      }
+      if (res.writableEnded) return; // response already done
+      if (!res.headersSent && res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
+      if (res.write) res.write(data);
+      if (res.end) res.end();
+    });
+  }
+
   handleProxyError(code, kind, req, res, e) {
     // called when proxy itself has an error
     // so far, just 404 for no target and 503 for target not responding
@@ -545,57 +587,55 @@ export class ConfigurableProxy extends EventEmitter {
 
       this.log.debug("Requesting custom error page: %s", url);
 
-      var errorRequest = (options.secure ? https : http).request(
-        url,
-        options.target,
-        (upstream) => {
-          if (res.writableEnded) {
-            // response already done
-            // make sure to consume upstream;
-            upstream.resume();
-            return;
-          }
-          ["content-type", "content-encoding"].map((key) => {
-            if (!upstream.headers[key]) return;
-            if (res.setHeader) res.setHeader(key, upstream.headers[key]);
-          });
-          if (res.writeHead) res.writeHead(code);
-          upstream.on("data", (data) => {
-            if (res.write && !res.writableEnded) res.write(data);
-          });
-          upstream.on("end", () => {
-            if (res.end) res.end();
-          });
-        }
-      );
-      errorRequest.on("error", (e) => {
-        // custom error failed, fallback on default
-        this.log.error("Failed to get custom error page: %s", e);
-        this._handleProxyErrorDefault(code, kind, req, res);
-      });
-      errorRequest.end();
-    } else if (this.errorPath) {
-      var filename = path.join(this.errorPath, code.toString() + ".html");
-      if (!fs.existsSync(filename)) {
-        this.log.debug("No error file %s", filename);
-        filename = path.join(this.errorPath, "error.html");
-        if (!fs.existsSync(filename)) {
-          this.log.error("No error file %s", filename);
-          this._handleProxyErrorDefault(code, kind, req, res);
+      var that = this;
+      var settled = false;
+      var errorRequest;
+      function settleErrorTargetFailure(err) {
+        if (settled) {
           return;
+        }
+        settled = true;
+        if (errorRequest) {
+          errorRequest.destroy();
+        }
+        var msg =
+          err && err.message === "error-target timeout"
+            ? err.message + " (" + that.errorTargetTimeout + "ms)"
+            : err;
+        that.log.error("Failed to get custom error page: %s", msg);
+        if (that.errorPath) {
+          that._handleProxyErrorFromPath(code, kind, req, res);
+        } else {
+          that._handleProxyErrorDefault(code, kind, req, res);
         }
       }
-      fs.readFile(filename, (err, data) => {
-        if (err) {
-          this.log.error("Error reading %s %s", filename, err);
-          this._handleProxyErrorDefault(code, kind, req, res);
+
+      errorRequest = (options.secure ? https : http).request(url, options.target, (upstream) => {
+        if (res.writableEnded) {
+          // response already done
+          // make sure to consume upstream;
+          upstream.resume();
           return;
         }
-        if (!res.writable) return; // response already done
-        if (res.writeHead) res.writeHead(code, { "Content-Type": "text/html" });
-        if (res.write) res.write(data);
-        if (res.end) res.end();
+        ["content-type", "content-encoding"].map((key) => {
+          if (!upstream.headers[key]) return;
+          if (res.setHeader) res.setHeader(key, upstream.headers[key]);
+        });
+        if (res.writeHead) res.writeHead(code);
+        upstream.on("data", (data) => {
+          if (res.write && !res.writableEnded) res.write(data);
+        });
+        upstream.on("end", () => {
+          if (res.end) res.end();
+        });
       });
+      errorRequest.setTimeout(this.errorTargetTimeout, function () {
+        settleErrorTargetFailure(new Error("error-target timeout"));
+      });
+      errorRequest.on("error", settleErrorTargetFailure);
+      errorRequest.end();
+    } else if (this.errorPath) {
+      this._handleProxyErrorFromPath(code, kind, req, res);
     } else {
       this._handleProxyErrorDefault(code, kind, req, res);
     }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -201,10 +201,7 @@ export class ConfigurableProxy extends EventEmitter {
     if (eto === undefined || eto === null) {
       eto = 10000;
     }
-    this.errorTargetTimeout = typeof eto === "string" ? parseInt(eto, 10) : Number(eto);
-    if (!Number.isFinite(this.errorTargetTimeout) || this.errorTargetTimeout < 1) {
-      this.errorTargetTimeout = 10000;
-    }
+    this.errorTargetTimeout = eto;
 
     if (this.options.enableMetrics) {
       this.metrics = new metrics.Metrics();

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,11 +187,34 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/c8": {
       "version": "11.0.0",
@@ -521,9 +544,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -817,29 +840,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -361,6 +361,66 @@ describe("Proxy Tests", function () {
       .then(done);
   });
 
+  it("error-target fetch fails and falls back to error-path files", function (done) {
+    proxy.errorTarget = "http://127.0.0.1:55599/";
+    proxy.errorPath = path.join(__dirname, "error");
+    proxy
+      .removeRoute("/")
+      .then(() => proxy.addRoute("/missing", { target: "https://127.0.0.1:54321" }))
+      .then(() => fetch(hostUrl + "/nope"))
+      .then((res) => {
+        expect(res.status).toEqual(404);
+        expect(res.headers.get("content-type")).toEqual("text/html");
+        return res.text();
+      })
+      .then((body) => {
+        expect(body).toMatch(/404/);
+      })
+      .then(() => fetch(hostUrl + "/missing/prefix"))
+      .then((res) => {
+        expect(res.status).toEqual(503);
+        expect(res.headers.get("content-type")).toEqual("text/html");
+        return res.text();
+      })
+      .then((body) => {
+        expect(body).toMatch(/UNKNOWN/);
+      })
+      .then(done);
+  });
+
+  it("error-target times out and falls back to error-path", function (done) {
+    const hang = http.createServer(() => {});
+    hang.listen(0, "127.0.0.1", () => {
+      const port = hang.address().port;
+      proxy.errorTarget = "http://127.0.0.1:" + port + "/";
+      proxy.errorPath = path.join(__dirname, "error");
+      proxy.errorTargetTimeout = 250;
+      proxy
+        .removeRoute("/")
+        .then(() => proxy.addRoute("/missing", { target: "https://127.0.0.1:54321" }))
+        .then(() => fetch(hostUrl + "/missing/prefix"))
+        .then((res) => {
+          expect(res.status).toEqual(503);
+          expect(res.headers.get("content-type")).toEqual("text/html");
+          return res.text();
+        })
+        .then((body) => {
+          expect(body).toMatch(/UNKNOWN/);
+        })
+        .then(
+          () =>
+            new Promise((resolve, reject) => {
+              hang.close((err) => (err ? reject(err) : resolve()));
+            })
+        )
+        .then(done)
+        .catch((e) => {
+          hang.close();
+          done.fail(e);
+        });
+    });
+  });
+
   it("custom error path", function (done) {
     proxy.errorPath = path.join(__dirname, "error");
     proxy


### PR DESCRIPTION
# Problem:

Today you must choose either --error-target or --error-path. If --error-target is set and the request to the custom error server fails (hub down, connection refused, etc.), CHP only returns the generic plain-text response. Static HTML under --error-path is never used in that case.

# Change:

Permit both --error-target and --error-path. When --error-target is configured, CHP still tries the custom error URL first. On request error, serve HTML from --error-path using the existing rules ({code}.html, then error.html, else default).

Fix --error-path CLI help: it is a directory of HTML files, not another proto://host server.

Add a test that uses an unreachable errorTarget and asserts responses come from the error-path fixtures.

# Backward compatibility:
Using only --error-target or only --error-path behaves as before. If both are set, behavior is: dynamic page when reachable; otherwise file-based fallback.