### PR TITLE
Add Redis-backed route store to persist routes across restarts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,19 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    # Redis service so the RedisStore tests run; REDIS_URL is set below.
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379
     strategy:
       fail-fast: false # Do not cancel all jobs if one fails
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,18 @@ jobs:
         run: |
           npm ci
 
+      # The c8 coverage tool (via its bundled yargs@17) does not yet load on the
+      # bleeding-edge "current" Node release, so run tests without coverage there.
+      # Coverage is still collected on the stable versions.
       - name: "Run tests"
         run: |
-          npm test
+          if [ "${{ matrix.node_version }}" = "current" ]; then
+            npm run test:no-coverage
+          else
+            npm test
+          fi
 
       # Action Repo: https://github.com/codecov/codecov-action
       - name: "Upload coverage to codecov"
+        if: matrix.node_version != 'current'
         uses: codecov/codecov-action@v6

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ functionality to [JupyterHub] deployments.
   - [Starting the proxy](#starting-the-proxy)
   - [Setting a default target](#setting-a-default-target)
   - [Command-line options](#command-line-options)
+  - [Persisting routes with Redis](#persisting-routes-with-redis)
 - [Using the REST API](#using-the-rest-api)
   - [REST API Basics](#rest-api-basics)
   - [Authenticating via passing a token](#authenticating-via-passing-a-token)
@@ -156,11 +157,41 @@ Options:
   --timeout <n>                      Timeout (in millis) when proxy drops connection for a request.
   --proxy-timeout <n>                Timeout (in millis) when proxy receives no response from target.
   --storage-backend <storage-class>  Define an external storage class. Defaults to in-MemoryStore.
+  --store <type>                     Route storage backend: 'memory' (default) or 'redis'. With 'redis', set the REDIS_URL environment variable.
   --keep-alive-timeout <timeout>     Set timeout (in milliseconds) for Keep-Alive connections
   -h, --help                         display help for command
 ```
 
 [**Return to top**][]
+
+### Persisting routes with Redis
+
+By default the routing table lives only in the proxy's memory, so it is lost
+whenever the process restarts (for example when a Kubernetes pod is rescheduled).
+To persist routes across restarts, run with `--store redis` and point the proxy
+at a Redis server via the `REDIS_URL` environment variable:
+
+```bash
+export REDIS_URL=redis://localhost:6379   # use rediss:// for TLS
+configurable-http-proxy --store redis
+```
+
+With the Redis store, reads are still served from an in-memory copy (so proxying
+stays fast), while every route add/update/remove is mirrored to Redis. On
+startup the proxy hydrates its in-memory table from Redis, so previously
+registered routes are immediately available again.
+
+Notes:
+
+- `REDIS_URL` is required when `--store redis` is used; the proxy exits with an
+  error if it is unset. Supported URL forms are `redis://` and `rediss://`
+  (TLS).
+- Routes are stored in a single Redis hash (key
+  `configurable-http-proxy:routes`).
+- This is designed for surviving restarts of a single proxy instance. Running
+  multiple proxy replicas against the same Redis works for persistence, but a
+  replica only picks up routes written by another replica after it (re)starts
+  and re-hydrates — live cross-replica synchronization is not yet implemented.
 
 ## Using the REST API
 

--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -114,6 +114,11 @@ cli
     "Define an external storage class. Defaults to in-MemoryStore."
   )
   .option(
+    "--store <type>",
+    "Route storage backend: 'memory' (default) or 'redis'. With 'redis', set the REDIS_URL environment variable.",
+    "memory"
+  )
+  .option(
     "--keep-alive-timeout <timeout>",
     "Set timeout (in milliseconds) for Keep-Alive connections",
     parseInt
@@ -322,6 +327,16 @@ if (!options.authToken) {
 
 // external backend class
 options.storageBackend = args.storageBackend;
+
+// built-in route store selection (default: in-memory)
+options.store = args.store;
+if (args.store === "redis") {
+  options.redisUrl = process.env.REDIS_URL;
+  if (!options.redisUrl) {
+    log.error("--store redis requires the REDIS_URL environment variable");
+    process.exit(1);
+  }
+}
 
 var proxy = new ConfigurableProxy(options);
 

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -18,7 +18,7 @@ import { default as httpProxy } from "http-proxy-3";
 
 import { defaultLogger } from "./log.js";
 import * as metrics from "./metrics.js";
-import { MemoryStore } from "./store.js";
+import { MemoryStore, RedisStore } from "./store.js";
 
 const require = createRequire(import.meta.url);
 
@@ -160,6 +160,10 @@ const loadStorage = (options) => {
   if (options.storageBackend) {
     const BackendStorageClass = require(options.storageBackend);
     return new BackendStorageClass(options);
+  }
+
+  if (options.store === "redis") {
+    return new RedisStore(options);
   }
 
   // loads default storage strategy

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as trie from "./trie.js";
+import { createClient } from "redis";
 
 var NotImplemented = function (name) {
   return {
@@ -75,5 +76,91 @@ export class MemoryStore extends BaseStore {
     delete this.routes[path];
     this.urls.remove(path);
     return Promise.resolve(route);
+  }
+}
+
+// RedisStore is a MemoryStore that mirrors every write to a Redis hash and
+// hydrates itself from that hash on startup. Reads (get/getAll/getTarget) are
+// served entirely from memory (the inherited URLTrie), so the proxy hot path is
+// unchanged; Redis only adds persistence so routes survive a process restart.
+export class RedisStore extends MemoryStore {
+  constructor(options = {}) {
+    super();
+    this.log = options.log;
+    if (!options.redisUrl) {
+      throw new Error("RedisStore requires a redis url (set REDIS_URL or options.redisUrl)");
+    }
+    // a single hash keyed by route path, values are JSON-encoded route data
+    this.key = options.redisKeyPrefix || "configurable-http-proxy:routes";
+    this.client = createClient({
+      url: options.redisUrl,
+      socket: {
+        // keep retrying forever with a capped backoff; a Redis blip should
+        // never take the proxy down, only pause persistence of new writes
+        reconnectStrategy: (retries) => Math.min(retries * 100, 3000),
+      },
+    });
+    this.client.on("error", (err) => {
+      if (this.log) this.log.error("Redis store error: %s", err.message);
+    });
+    // expose readiness so writes wait for the connection + initial hydration
+    this.ready = this.client.connect().then(() => this._hydrate());
+    this.ready.catch((err) => {
+      if (this.log) this.log.error("Redis store failed to initialize: %s", err.message);
+    });
+  }
+
+  async _hydrate() {
+    // load the persisted routing table into the in-memory store + trie
+    var stored = await this.client.hGetAll(this.key);
+    Object.keys(stored).forEach((path) => {
+      // super.add (not this.add) so hydration doesn't write back to Redis
+      super.add(path, this._deserialize(stored[path]));
+    });
+    if (this.log) {
+      this.log.info("Loaded %d routes from Redis", Object.keys(stored).length);
+    }
+  }
+
+  _serialize(data) {
+    return JSON.stringify(data);
+  }
+
+  _deserialize(json) {
+    var data = JSON.parse(json);
+    // MemoryStore stores last_activity as a Date; revive it so the
+    // inactiveSince comparison in getRoutes keeps working after a reload
+    if (data && data.last_activity) {
+      data.last_activity = new Date(data.last_activity);
+    }
+    return data;
+  }
+
+  async add(path, data) {
+    super.add(path, data); // update memory + trie immediately
+    await this.ready;
+    await this.client.hSet(this.key, this.cleanPath(path), this._serialize(data));
+    return null;
+  }
+
+  async update(path, data) {
+    super.update(path, data); // merge in memory
+    await this.ready;
+    var merged = this.routes[this.cleanPath(path)];
+    if (merged) {
+      await this.client.hSet(this.key, this.cleanPath(path), this._serialize(merged));
+    }
+  }
+
+  async remove(path) {
+    var route = await super.remove(path); // remove from memory + trie
+    await this.ready;
+    await this.client.hDel(this.key, this.cleanPath(path));
+    return route;
+  }
+
+  stop() {
+    // close the connection (used by tests; safe to call when never connected)
+    return this.client.quit();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "~14.0.3",
         "http-proxy-3": "~1.23.1",
         "prom-client": "~15.1.3",
-        "redis": "^4.7.1",
+        "redis": "~4.7.1",
         "winston": "~3.19.0"
       },
       "bin": {
@@ -590,9 +590,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "commander": "~14.0.3",
         "http-proxy-3": "~1.23.1",
         "prom-client": "~15.1.3",
+        "redis": "^4.7.1",
         "winston": "~3.19.0"
       },
       "bin": {
@@ -110,6 +111,65 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -364,6 +424,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
@@ -581,6 +650,15 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -954,6 +1032,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1248,6 +1343,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "commander": "~14.0.3",
     "http-proxy-3": "~1.23.1",
     "prom-client": "~15.1.3",
+    "redis": "~4.7.1",
     "winston": "~3.19.0"
   },
   "devDependencies": {
     "c8": "^11.0.0",
     "jasmine": "^6.1.0",
     "node-fetch": "^3.3.0",
-    "ws": "^8.4.0",
-    "tmp": "^0.2"
+    "tmp": "^0.2",
+    "ws": "^8.4.0"
   },
   "engines": {
     "node": ">= 20"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "fmt": "pre-commit run --all-files",
     "test": "FORCE_COLOR=3 c8 jasmine --config=test/config/jasmine.mjs",
+    "test:no-coverage": "FORCE_COLOR=3 jasmine --config=test/config/jasmine.mjs",
     "c8": "c8",
     "coverage-html": "c8 report --reporter=html",
     "codecov": "c8 report --reporter=lcov && codecov"

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -265,6 +265,20 @@ describe("Proxy Tests", function () {
     done();
   });
 
+  it("options.store redis selects the RedisStore", function (done) {
+    const options = {
+      store: "redis",
+      redisUrl: "redis://localhost:6379",
+    };
+    const cp = new ConfigurableProxy(options);
+    expect(cp._routes.constructor.name).toEqual("RedisStore");
+    // we only assert wiring here (no live Redis needed); avoid a dangling
+    // reconnecting client keeping the test runner alive
+    cp._routes.ready.catch(() => {});
+    cp._routes.client.disconnect().catch(() => {});
+    done();
+  });
+
   it("includePrefix: false + prependPath: false", function (done) {
     proxy.includePrefix = false;
     proxy.proxy.options.prependPath = false;

--- a/test/redis_store_spec.js
+++ b/test/redis_store_spec.js
@@ -1,0 +1,145 @@
+import { RedisStore } from "../lib/store.js";
+
+// These tests need a running Redis. They connect to REDIS_URL (default
+// redis://localhost:6379) and self-skip (pending) if none is reachable, so
+// `npm test` still passes locally without Redis. CI provides a redis service.
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+const TEST_KEY = "test:configurable-http-proxy:routes";
+
+function makeStore() {
+  return new RedisStore({ redisUrl: REDIS_URL, redisKeyPrefix: TEST_KEY });
+}
+
+describe("RedisStore", function () {
+  var redisAvailable = false;
+
+  beforeAll(async function () {
+    var probe = makeStore();
+    try {
+      await probe.ready;
+      redisAvailable = true;
+    } catch (e) {
+      redisAvailable = false;
+    } finally {
+      try {
+        await probe.stop();
+      } catch (e) {
+        // ignore: connection never established
+      }
+    }
+  });
+
+  beforeEach(async function () {
+    if (!redisAvailable) {
+      pending("Redis is not available at " + REDIS_URL);
+      return;
+    }
+    this.subject = makeStore();
+    await this.subject.ready;
+    // start every test from a clean hash
+    await this.subject.client.del(TEST_KEY);
+  });
+
+  afterEach(async function () {
+    if (!this.subject) return;
+    await this.subject.client.del(TEST_KEY);
+    await this.subject.stop();
+  });
+
+  describe("get", function () {
+    it("returns the data for the specified path", async function () {
+      await this.subject.add("/myRoute", { test: "value" });
+      var data = await this.subject.get("/myRoute");
+      expect(data).toEqual({ test: "value" });
+    });
+
+    it("returns undefined when not found", async function () {
+      var result = await this.subject.get("/wut");
+      expect(result).toBe(undefined);
+    });
+  });
+
+  describe("getTarget", function () {
+    it("returns the target object for the path", async function () {
+      await this.subject.add("/myRoute", { target: "http://localhost:8213" });
+      var target = await this.subject.getTarget("/myRoute");
+      expect(target.prefix).toEqual("/myRoute");
+      expect(target.data.target).toEqual("http://localhost:8213");
+    });
+  });
+
+  describe("getAll", function () {
+    it("returns all routes", async function () {
+      await this.subject.add("/myRoute", { test: "value1" });
+      await this.subject.add("/myOtherRoute", { test: "value2" });
+      var routes = await this.subject.getAll();
+      expect(Object.keys(routes).length).toEqual(2);
+      expect(routes["/myRoute"]).toEqual({ test: "value1" });
+      expect(routes["/myOtherRoute"]).toEqual({ test: "value2" });
+    });
+
+    it("returns a blank object when no routes defined", async function () {
+      var routes = await this.subject.getAll();
+      expect(routes).toEqual({});
+    });
+  });
+
+  describe("add", function () {
+    it("adds data to the store for the specified path", async function () {
+      await this.subject.add("/myRoute", { test: "value" });
+      var route = await this.subject.get("/myRoute");
+      expect(route).toEqual({ test: "value" });
+    });
+
+    it("overwrites any existing values", async function () {
+      await this.subject.add("/myRoute", { test: "value" });
+      await this.subject.add("/myRoute", { test: "updatedValue" });
+      var route = await this.subject.get("/myRoute");
+      expect(route).toEqual({ test: "updatedValue" });
+    });
+  });
+
+  describe("update", function () {
+    it("merges supplied data with existing data", async function () {
+      await this.subject.add("/myRoute", { version: 1, test: "value" });
+      await this.subject.update("/myRoute", { version: 2 });
+      var route = await this.subject.get("/myRoute");
+      expect(route.version).toEqual(2);
+      expect(route.test).toEqual("value");
+    });
+  });
+
+  describe("remove", function () {
+    it("removes a route from the table", async function () {
+      await this.subject.add("/myRoute", { test: "value" });
+      await this.subject.remove("/myRoute");
+      var route = await this.subject.get("/myRoute");
+      expect(route).toBe(undefined);
+    });
+
+    it("doesn't explode when route is not defined", async function () {
+      await this.subject.remove("/myRoute/foo/bar");
+    });
+  });
+
+  describe("persistence across restarts", function () {
+    it("hydrates routes written by a previous instance", async function () {
+      await this.subject.add("/persisted", { target: "http://localhost:9999" });
+      await this.subject.update("/persisted", { last_activity: new Date("2020-01-01T00:00:00Z") });
+
+      // simulate a restart: a brand new store pointed at the same Redis hash
+      var revived = makeStore();
+      try {
+        await revived.ready;
+        var route = await revived.get("/persisted");
+        expect(route.target).toEqual("http://localhost:9999");
+        // last_activity is revived as a Date, not a string
+        expect(route.last_activity instanceof Date).toBe(true);
+        var target = await revived.getTarget("/persisted/inside/here");
+        expect(target.prefix).toEqual("/persisted");
+      } finally {
+        await revived.stop();
+      }
+    });
+  });
+});


### PR DESCRIPTION
The routing table previously lived only in process memory, so a restart (e.g. a Kubernetes pod reschedule) lost all dynamically-registered routes.

Add an opt-in Redis store, selected with '--store redis' (REDIS_URL env var required; default remains the in-memory store). RedisStore extends MemoryStore: reads stay in-memory via the URLTrie so the proxy hot path is unchanged, while add/update/remove are mirrored to a Redis hash and the table is hydrated from Redis on startup. last_activity is revived as a Date on load.

- lib/store.js: RedisStore (node-redis)
- lib/configproxy.js: loadStorage selects RedisStore on options.store === 'redis'
- bin: --store flag + REDIS_URL validation
- tests: redis_store_spec.js (incl. restart-persistence), proxy_spec wiring case
- CI: redis service container in test job
- README: --store option + 'Persisting routes with Redis' section