### PR TITLE
Standardize unix socket protocol to http+unix

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -538,7 +538,7 @@ export class ConfigurableProxy extends EventEmitter {
       var url = "";
       if (options.target.socketPath) {
         options.target.hostname = "localhost";
-        url = options.target.toString().replace("http+unix", "http")
+        url = options.target.toString().replace("http+unix", "http");
       } else {
         url = options.target.toString();
       }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -424,7 +424,7 @@ export class ConfigurableProxy extends EventEmitter {
   proxyOptsForTarget(target) {
     var proxyOptions = { target };
 
-    if (target.protocol === "http+unix" || target.protocol === "unix+http") {
+    if (target.protocol.startsWith("http+unix") || target.protocol.startsWith("unix+http")) {
       // No need for agents for unix sockets
       // No support for https for unix sockets
       proxyOptions.secure = false;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -424,7 +424,7 @@ export class ConfigurableProxy extends EventEmitter {
   proxyOptsForTarget(target) {
     var proxyOptions = { target };
 
-    if (target.protocol.startsWith("http+unix")) {
+    if (target.protocol === "http+unix" || target.protocol === "unix+http") {
       // No need for agents for unix sockets
       // No support for https for unix sockets
       proxyOptions.secure = false;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -424,7 +424,7 @@ export class ConfigurableProxy extends EventEmitter {
   proxyOptsForTarget(target) {
     var proxyOptions = { target };
 
-    if (target.protocol.startsWith("unix")) {
+    if (target.protocol.startsWith("http+unix")) {
       // No need for agents for unix sockets
       // No support for https for unix sockets
       proxyOptions.secure = false;
@@ -538,7 +538,7 @@ export class ConfigurableProxy extends EventEmitter {
       var url = "";
       if (options.target.socketPath) {
         options.target.hostname = "localhost";
-        url = options.target.toString().substring(5); // chop off unix+
+        url = options.target.toString().replace("http+unix", "http")
       } else {
         url = options.target.toString();
       }

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -538,7 +538,7 @@ export class ConfigurableProxy extends EventEmitter {
       var url = "";
       if (options.target.socketPath) {
         options.target.hostname = "localhost";
-        url = options.target.toString().replace("http+unix", "http");
+        url = options.target.toString().replace("http+unix", "http").replace("unix+http", "http");
       } else {
         url = options.target.toString();
       }

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -16,8 +16,7 @@ export function addTarget(proxy, path, port, websocket, targetPath, sslOptions, 
 
   if (unixSocketPath) {
     listenTarget = decodeURIComponent(unixSocketPath);
-    proto = "http";
-    target = "unix+" + proto + "://" + unixSocketPath;
+    target = "http+unix://" + unixSocketPath;
   } else {
     proto = sslOptions ? "https" : "http";
     target = proto + "://" + "127.0.0.1:" + port;
@@ -135,7 +134,7 @@ export function setupProxy(listenOptions, options, paths) {
     });
     errorServer.on("listening", onlisten);
     const errorUrl = new URL(options.errorTarget);
-    if (errorUrl.href.startsWith("unix+")) {
+    if (errorUrl.href.startsWith("http+unix")) {
       console.log(decodeURIComponent(errorUrl.hostname));
       errorServer.listen(decodeURIComponent(errorUrl.hostname));
     } else {

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -536,7 +536,7 @@ describe("Proxy Tests", function () {
     var unixSocketUri = encodeURIComponent(tmp.tmpNameSync());
 
     util
-      .setupProxy(listenOptions, { errorTarget: "unix+http://" + unixSocketUri }, [])
+      .setupProxy(listenOptions, { errorTarget: "http+unix://" + unixSocketUri }, [])
       .then(() => fetch("http://127.0.0.1:" + listenOptions.port + "/foo/bar"))
       .then((res) => {
         expect(res.status).toEqual(404);


### PR DESCRIPTION
As discussed in https://github.com/jupyterhub/jupyterhub/pull/5397, it would be good to standardize the protocol used for unix sockets across jupyter projects. `jupyter-server` already uses `http+unix`, as do other popular projects.

This PR replaces unix+http with http+unix throughout this project.

I think the only consequence is that currently, the implementation technically supports `unix+https` (https on unix socket), since we check for URLs *starting* with `"unix+"`. However, checking for URLs that start with `"http+unix"` excludes `"https+unix"`. We could check for `http+unix` *or* `https+unix`, but I wonder if this is worth it. SSL over unix sockets is technically possible, I think, but I don't know why anyone would really want to use it...