### PR TITLE
Remove mentions of Node 18 (not supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ functionality to [JupyterHub] deployments.
 
 ## Install
 
-Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 18
+Prerequisite: [Node.js](https://nodejs.org/en/download/) ≥ 20
 
 If you're installing `configurable-http-proxy` in Linux, you can follow [the instruction of nodesource](https://github.com/nodesource/distributions#installation-instructions) to install arbitrary version of Node.js.
 

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -172,8 +172,5 @@ export function teardownServers(callback) {
   };
   for (var i = servers.length - 1; i >= 0; i--) {
     servers[i].close(onclose);
-    // closeAllConnections is implied in close in node >=19
-    // but this avoids waits between all tests with node 18
-    servers[i].closeAllConnections();
   }
 }

--- a/test/cli_spec.js
+++ b/test/cli_spec.js
@@ -85,9 +85,6 @@ function teardownServers() {
   };
   for (var i = servers.length - 1; i >= 0; i--) {
     servers[i].close(onclose);
-    // closeAllConnections is implied in close in node >=19
-    // but this avoids waits between all tests with node 18
-    servers[i].closeAllConnections();
   }
 }
 


### PR DESCRIPTION
The 5.2.0 changelog says `node >=20` is required, but we still mention 18 in a few places including in the readme

https://github.com/jupyterhub/configurable-http-proxy/blob/5.3.0/CHANGELOG.md#520---2026-03-11

### Checklist


- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [x] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->

### What should a reviewer concentrate their feedback on?
I've cleaned up a couple of tests based on the code comments, but please check!

### Other information
<!--
Please provide any other information you think is relevant
-->
